### PR TITLE
feat: replace Google Fonts with @fontsource package

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -4,6 +4,7 @@
     "": {
       "name": "sunburn-calc",
       "dependencies": {
+        "@fontsource/tiktok-sans": "^5.2.2",
         "@radix-ui/react-accordion": "^1.2.11",
         "@radix-ui/react-label": "^2.1.7",
         "@radix-ui/react-progress": "^1.1.7",
@@ -177,6 +178,8 @@
     "@floating-ui/react-dom": ["@floating-ui/react-dom@2.1.4", "", { "dependencies": { "@floating-ui/dom": "^1.7.2" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-JbbpPhp38UmXDDAu60RJmbeme37Jbgsm7NrHGgzYYFKmblzRUh6Pa641dII6LsjwF4XlScDrde2UAzDo/b9KPw=="],
 
     "@floating-ui/utils": ["@floating-ui/utils@0.2.10", "", {}, "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ=="],
+
+    "@fontsource/tiktok-sans": ["@fontsource/tiktok-sans@5.2.2", "", {}, "sha512-L2MKMXpYc3WsnHVpa4AUqzXonKYdsUqcIGILA0Kkoxwa/Xdh1aJuck+a0j6jXoaFK0Zlj1LSbYugc0jtVDh3Ag=="],
 
     "@humanfs/core": ["@humanfs/core@0.19.1", "", {}, "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA=="],
 

--- a/index.html
+++ b/index.html
@@ -13,10 +13,6 @@
     <meta name="theme-color" content="#f97316" />
     <meta name="color-scheme" content="light" />
 
-    <!-- Fonts -->
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=TikTok+Sans:opsz,wght@12..36,300..900&display=swap" rel="stylesheet">
 
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website" />

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
 		"test:watch": "bun test --watch"
 	},
 	"dependencies": {
+		"@fontsource/tiktok-sans": "^5.2.2",
 		"@radix-ui/react-accordion": "^1.2.11",
 		"@radix-ui/react-label": "^2.1.7",
 		"@radix-ui/react-progress": "^1.1.7",

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,6 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
-import "@fontsource/tiktok-sans";
+import "@fontsource/tiktok-sans/index.css";
 import "./index.css";
 import App from "./App.tsx";
 import { Analytics } from "@vercel/analytics/react";

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,6 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
+import "@fontsource/tiktok-sans";
 import "./index.css";
 import App from "./App.tsx";
 import { Analytics } from "@vercel/analytics/react";


### PR DESCRIPTION
## Summary
- Replaced Google Fonts CDN with local @fontsource package for TikTok Sans
- Removes external dependency on fonts.googleapis.com
- Improves privacy by eliminating third-party font requests

## Changes
- Install @fontsource/tiktok-sans package  
- Import font directly in main.tsx
- Remove Google Fonts preconnect and stylesheet links from index.html

## Benefits
- **Privacy**: No external font requests to Google
- **Performance**: Fonts bundled locally, no additional network requests
- **Reliability**: No dependency on external CDN availability
- **Compliance**: Better for GDPR/privacy-focused deployments

## Test plan
- [ ] Verify TikTok Sans font loads correctly in development
- [ ] Check production build includes font assets
- [ ] Confirm no console errors related to font loading
- [ ] Test across different browsers and devices

🤖 Generated with [Claude Code](https://claude.ai/code)