### PR TITLE
feat: Sun Presence - add radial glow and directional shadows

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -94,8 +94,10 @@ function App() {
 	const showSweatLevel = spfLevel !== undefined && spfLevel !== SPFLevel.NONE;
 
 	return (
-		<div className="min-h-screen bg-orange-50">
-			<div className="container mx-auto px-4 py-8 max-w-4xl">
+		<div className="min-h-screen sun-glow relative overflow-hidden">
+			{/* Subtle sun rays decoration */}
+			<div className="sun-rays absolute inset-0" aria-hidden="true" />
+			<div className="container mx-auto px-4 py-8 max-w-4xl relative">
 				{/* Header */}
 				<div className="mb-8">
 					<div className="flex items-center mb-2">
@@ -122,7 +124,7 @@ function App() {
 					{/* Step 1: Skin Type */}
 					<AccordionItem
 						value="step1"
-						className="bg-card border-stone-200 shadow-sm rounded-lg mb-4"
+						className="bg-card border-stone-200 shadow-sun rounded-lg mb-4"
 					>
 						<AccordionTrigger className="px-6 py-4 hover:no-underline">
 							<div className="flex-1 text-left">
@@ -148,7 +150,7 @@ function App() {
 					{/* Step 2: Sunscreen */}
 					<AccordionItem
 						value="step2"
-						className="bg-card border-stone-200 shadow-sm rounded-lg mb-4"
+						className="bg-card border-stone-200 shadow-sun rounded-lg mb-4"
 					>
 						<AccordionTrigger className="px-6 py-4 hover:no-underline">
 							<div className="flex-1 text-left">
@@ -192,7 +194,7 @@ function App() {
 					{/* Step 3: Location & Weather */}
 					<AccordionItem
 						value="step3"
-						className="bg-card border-stone-200 shadow-sm rounded-lg mb-4"
+						className="bg-card border-stone-200 shadow-sun rounded-lg mb-4"
 					>
 						<AccordionTrigger className="px-6 py-4 hover:no-underline">
 							<div className="flex-1 text-left">

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -7,7 +7,7 @@ function Card({ className, ...props }: React.ComponentProps<"div">) {
 		<div
 			data-slot="card"
 			className={cn(
-				"bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm",
+				"bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sun",
 				className,
 			)}
 			{...props}

--- a/src/index.css
+++ b/src/index.css
@@ -119,3 +119,50 @@
 		@apply bg-background text-foreground;
 	}
 }
+
+/* Sun presence - radial glow from top-right corner */
+.sun-glow {
+	background:
+		radial-gradient(
+			ellipse 80% 60% at 90% -10%,
+			rgba(251, 191, 36, 0.25) 0%,
+			rgba(251, 191, 36, 0.1) 30%,
+			rgba(255, 237, 213, 0.05) 60%,
+			transparent 80%
+		),
+		linear-gradient(to bottom, rgb(255, 247, 237) 0%, rgb(255, 251, 245) 100%);
+}
+
+/* Directional shadows - light source from top-right */
+.shadow-sun {
+	box-shadow:
+		-2px 3px 8px -2px rgba(0, 0, 0, 0.08),
+		-1px 2px 4px -1px rgba(0, 0, 0, 0.04);
+}
+
+.shadow-sun-lg {
+	box-shadow:
+		-4px 6px 16px -4px rgba(0, 0, 0, 0.1),
+		-2px 3px 6px -2px rgba(0, 0, 0, 0.06);
+}
+
+/* Subtle light ray decoration */
+.sun-rays::before {
+	content: "";
+	position: absolute;
+	top: 0;
+	right: 0;
+	width: 300px;
+	height: 300px;
+	background: conic-gradient(
+		from 180deg at 100% 0%,
+		transparent 0deg,
+		rgba(251, 191, 36, 0.03) 15deg,
+		transparent 30deg,
+		rgba(251, 191, 36, 0.02) 45deg,
+		transparent 60deg,
+		rgba(251, 191, 36, 0.03) 75deg,
+		transparent 90deg
+	);
+	pointer-events: none;
+}


### PR DESCRIPTION
## Summary

- Add `sun-glow` class with radial gradient emanating from top-right corner
- Create `shadow-sun` classes with consistent light source direction
- Add subtle conic-gradient sun rays decoration
- Update Card component to use directional shadows
- Apply sun-glow background to main app container

## Design Philosophy

The sunny theme was previously just "orange background". This PR makes the sun feel **present**:

1. **Implied light source** - All shadows now come from a consistent top-right direction
2. **Radial warmth** - A soft glow suggests sun presence without being literal
3. **Subtle ray decoration** - Very light conic gradient adds depth without distraction

## Visual Changes

The background now has:
- A warm radial gradient suggesting sun position
- Cards cast shadows as if lit from above-right
- Overall warmer, more intentional feel

## Test plan
- [ ] Check background glow is visible but subtle
- [ ] Verify card shadows have directional quality
- [ ] Test on different viewport sizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)