### PR TITLE
Anchor UV interpolation to current observation and add location search/SEO artifacts

### DIFF
--- a/src/calculations.test.ts
+++ b/src/calculations.test.ts
@@ -17,7 +17,7 @@ function createMockWeatherData(
 			feels_like: 75,
 			pressure: 1013,
 			humidity: 50,
-			uvi: uvValues[0] || 5,
+			uvi: uvValues[0] ?? 5,
 			clouds: 20,
 			wind_speed: 5,
 			weather: [
@@ -62,6 +62,29 @@ function createTestScenario(
 		skinType,
 		spfLevel,
 		sweatLevel,
+	};
+}
+
+function createObservedCurrentUvScenario(
+	forecastUvValues: number[],
+	currentObservedUvi: number,
+	currentTime: Date,
+): CalculationInput {
+	const hourStartSeconds = Math.floor(
+		new Date(currentTime).setMinutes(0, 0, 0) / 1000,
+	);
+	const weather = createMockWeatherData(forecastUvValues, hourStartSeconds);
+
+	weather.current.dt = Math.floor(currentTime.getTime() / 1000);
+	weather.current.uvi = currentObservedUvi;
+
+	return {
+		weather,
+		placeName: "Test Location",
+		currentTime,
+		skinType: FitzpatrickType.II,
+		spfLevel: SPFLevel.NONE,
+		sweatLevel: SweatLevel.LOW,
 	};
 }
 
@@ -225,6 +248,60 @@ describe("Sunburn Calculation Algorithm", () => {
 				lowUVResult,
 				lowUV,
 				"High UV should cause faster burning than low UV",
+			);
+		});
+	});
+
+	describe("Current UV Anchoring", () => {
+		it("uses the observed current UV for the first forecast segment when current UV is lower", () => {
+			const currentTime = new Date("2025-09-06T09:30:00");
+			const anchoredInput = createObservedCurrentUvScenario(
+				[8, 8, 8, 8],
+				2,
+				currentTime,
+			);
+			const forecastOnlyInput = createObservedCurrentUvScenario(
+				[8, 8, 8, 8],
+				8,
+				currentTime,
+			);
+
+			const anchoredResult = findOptimalTimeSlicing(anchoredInput);
+			const forecastOnlyResult = findOptimalTimeSlicing(forecastOnlyInput);
+
+			expect(anchoredResult.points[0]?.slice.uvIndex).toBeLessThan(4);
+			expectRelativeBurnTime(
+				forecastOnlyResult,
+				forecastOnlyInput,
+				anchoredResult,
+				anchoredInput,
+				"Lower observed current UV should extend the near-term burn estimate",
+			);
+		});
+
+		it("uses the observed current UV for the first forecast segment when current UV is higher", () => {
+			const currentTime = new Date("2025-09-06T09:30:00");
+			const anchoredInput = createObservedCurrentUvScenario(
+				[6, 6, 6, 6],
+				10,
+				currentTime,
+			);
+			const forecastOnlyInput = createObservedCurrentUvScenario(
+				[6, 6, 6, 6],
+				6,
+				currentTime,
+			);
+
+			const anchoredResult = findOptimalTimeSlicing(anchoredInput);
+			const forecastOnlyResult = findOptimalTimeSlicing(forecastOnlyInput);
+
+			expect(anchoredResult.points[0]?.slice.uvIndex).toBeGreaterThan(7);
+			expectRelativeBurnTime(
+				anchoredResult,
+				anchoredInput,
+				forecastOnlyResult,
+				forecastOnlyInput,
+				"Higher observed current UV should shorten the near-term burn estimate",
 			);
 		});
 	});

--- a/src/calculations.ts
+++ b/src/calculations.ts
@@ -3,7 +3,6 @@ import type {
 	CalculationResult,
 	CalculationPoint,
 	TimeSlice,
-	HourlyWeather,
 	FitzpatrickType,
 } from "./types";
 import {
@@ -74,34 +73,72 @@ type SliceWindow = {
 	uviEnd: number;
 };
 
+function interpolateUvi(
+	startUvi: number,
+	endUvi: number,
+	fraction: number,
+): number {
+	return startUvi * (1 - fraction) + endUvi * fraction;
+}
+
 // **Build fixed sub-hour slices, keeping start & end UV for trapezoid integration
 // Breaks hourly UV data into smaller windows (e.g., 10-min) with interpolated UV at start/end.
 // This allows averaging UV changes smoothly, like connecting dots on a graph.**
 function createSlices(
-	hourly: HourlyWeather[],
+	input: CalculationInput,
 	slicesPerHour: number,
 ): SliceWindow[] {
 	const sliceWindows: SliceWindow[] = [];
+	const { hourly, current } = input.weather;
 	if (!hourly || hourly.length < 2) return sliceWindows;
 	const sliceMinutes = 60 / slicesPerHour;
+	const sliceDurationMs = sliceMinutes * 60000;
+	const currentObservationMs = current.dt * 1000;
 	for (let i = 0; i < hourly.length - 1; i++) {
 		const currentHourWeather = hourly[i];
 		const nextHourWeather = hourly[i + 1];
 		const baseTimestampMs = currentHourWeather.dt * 1000;
-		for (let j = 0; j < slicesPerHour; j++) {
-			const sliceStartMs = baseTimestampMs + j * sliceMinutes * 60000;
-			const sliceEndMs = baseTimestampMs + (j + 1) * sliceMinutes * 60000;
-			const interpFractionStart = j / slicesPerHour;
-			const interpFractionEnd = (j + 1) / slicesPerHour;
+		const nextTimestampMs = nextHourWeather.dt * 1000;
+		let anchorStartMs = baseTimestampMs;
+		let anchorStartUvi = currentHourWeather.uvi;
+
+		if (
+			currentObservationMs >= baseTimestampMs &&
+			currentObservationMs < nextTimestampMs
+		) {
+			anchorStartMs = currentObservationMs;
+			anchorStartUvi = current.uvi;
+		}
+
+		const intervalDurationMs = nextTimestampMs - anchorStartMs;
+		if (intervalDurationMs <= 0) continue;
+
+		for (
+			let sliceStartMs = anchorStartMs;
+			sliceStartMs < nextTimestampMs;
+			sliceStartMs += sliceDurationMs
+		) {
+			const sliceEndMs = Math.min(
+				sliceStartMs + sliceDurationMs,
+				nextTimestampMs,
+			);
+			const interpFractionStart =
+				(sliceStartMs - anchorStartMs) / intervalDurationMs;
+			const interpFractionEnd =
+				(sliceEndMs - anchorStartMs) / intervalDurationMs;
 			sliceWindows.push({
 				start: new Date(sliceStartMs),
 				end: new Date(sliceEndMs),
-				uviStart:
-					currentHourWeather.uvi * (1 - interpFractionStart) +
-					nextHourWeather.uvi * interpFractionStart,
-				uviEnd:
-					currentHourWeather.uvi * (1 - interpFractionEnd) +
-					nextHourWeather.uvi * interpFractionEnd,
+				uviStart: interpolateUvi(
+					anchorStartUvi,
+					nextHourWeather.uvi,
+					interpFractionStart,
+				),
+				uviEnd: interpolateUvi(
+					anchorStartUvi,
+					nextHourWeather.uvi,
+					interpFractionEnd,
+				),
 			});
 		}
 	}
@@ -174,7 +211,7 @@ function calculateBurnTimeWithSlices(
 	input: CalculationInput,
 	slicesPerHour: number,
 ): CalculationResult {
-	const sliceWindows = createSlices(input.weather.hourly, slicesPerHour);
+	const sliceWindows = createSlices(input, slicesPerHour);
 	const medInJm2 = getMedInJm2(input.skinType);
 	const baseSpfValue =
 		SPF_CONFIG[input.spfLevel]?.coefficient ??


### PR DESCRIPTION
## Summary
- Anchor UV interpolation to the current observed UV reading so near-term burn-time estimates better reflect live conditions.
- Update time-based burn logic to use the location timezone (including evening cutoff/risk checks).
- Add city autocomplete location search (Open-Meteo geocoding) and wire selection into weather fetch flow.
- Pass timezone through results/sun-position UI paths for timezone-correct display logic.
- Add FAQ and Sun Safety Resources components plus SEO/research planning docs and notes.
- Include supporting project artifacts (`api/llm-summary.js`, `.vercel/*`, `README.md.bak`, `pr27.diff`).

## Testing
- Updated unit test fixtures in `src/calculations.test.ts` to include `sunrise`, `sunset`, and `timezone` fields required by updated weather shape.
- Concrete check to run: verify burn-time output changes when current UV diverges from hourly forecast first segment (regression check for anchored interpolation).
- Concrete check to run: verify evening cutoff behavior uses selected location timezone (not browser local timezone).
- Concrete check to run: keyboard and click selection in location autocomplete fetches weather for selected coordinates.
- Not run: full automated test suite and end-to-end/manual UI validation in this PR context.