### PR TITLE
Style: Refactor Accordion Component

### DIFF
--- a/src/components/ui/accordion.tsx
+++ b/src/components/ui/accordion.tsx
@@ -31,11 +31,11 @@ function AccordionTrigger({
 	...props
 }: React.ComponentProps<typeof AccordionPrimitive.Trigger>) {
 	return (
-		<AccordionPrimitive.Header className="flex">
+		<AccordionPrimitive.Header className="flex data-[state=open]:mb-4">
 			<AccordionPrimitive.Trigger
 				data-slot="accordion-trigger"
 				className={cn(
-					"focus-visible:border-ring focus-visible:ring-ring/50 flex flex-1 items-start justify-between gap-4 rounded-md py-4 text-left text-sm font-medium transition-all outline-none hover:underline focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50 [&[data-state=open]>svg]:rotate-180",
+					"focus-visible:border-ring focus-visible:ring-ring/50 flex flex-1 items-start justify-between gap-4 rounded-md px-6 py-4 text-left text-sm font-medium transition-all outline-none hover:no-underline focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50 [&[data-state=open]>svg]:rotate-180",
 					className,
 				)}
 				{...props}
@@ -59,7 +59,7 @@ function AccordionContent({
 	return (
 		<AccordionPrimitive.Content
 			data-slot="accordion-content"
-			className="data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down overflow-hidden text-sm"
+			className="data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down overflow-hidden text-sm relative z-10 data-[state=open]:overflow-visible"
 			{...props}
 		>
 			<div className={cn("pt-0 pb-4", className)}>{children}</div>


### PR DESCRIPTION
Refactors the Accordion component to support state-based layout (padding vs margin) and improves visibility for expanding animations.


Before:
<img width="413" height="293" alt="image" src="https://github.com/user-attachments/assets/d9eead3f-8e0d-4922-967a-769bf6468488" />

After:
<img width="445" height="299" alt="image" src="https://github.com/user-attachments/assets/53a71749-d211-4159-b1a4-38bb972c6b2a" />
