### PR TITLE
Use existing app logo in header instead of custom SVG

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from "react";
-import { RefreshCw, Sun } from "lucide-react";
+import { RefreshCw } from "lucide-react";
 import { haptic } from "ios-haptics";
 import { useAppStore, useIsReadyToCalculate } from "./store";
 import { findOptimalTimeSlicing } from "./calculations";
@@ -115,7 +115,12 @@ function App() {
 				{/* Header */}
 				<div className="mb-8">
 					<div className="flex items-center mb-2">
-						<Sun className="w-8 h-8 text-amber-600 mr-4" />
+						<img
+							src="/favicon.svg"
+							alt=""
+							aria-hidden="true"
+							className="w-12 h-12 mr-3"
+						/>
 						<h1 className="text-3xl font-bold text-slate-800">
 							Sunburn Calculator
 						</h1>


### PR DESCRIPTION
### Motivation
- Remove a newly added duplicate SVG asset and align the header with the app's existing branding by using the already-present favicon. 
- Improve accessibility semantics for the header icon by treating it as decorative since the adjacent heading provides the label.

### Description
- Updated `src/App.tsx` to render the existing `/favicon.svg` instead of importing `src/assets/sunburntimer-logo.svg` and removed the now-unused `Sun` icon import. 
- Marked the header image as decorative with `alt=""` and `aria-hidden="true"` and adjusted the Tailwind sizing classes to `w-12 h-12 mr-3`. 
- Deleted the previously added `src/assets/sunburntimer-logo.svg` file.

### Testing
- Ran `bun test` and all tests passed (`27 pass`, `0 fail`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e83eb253588325b31d40b25986745c)