### PR TITLE
Add forecast-backed start time selector

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,7 @@ import { SkinTypeSelector } from "./components/SkinTypeSelector";
 import { SPFSelector } from "./components/SPFSelector";
 import { SweatLevelSelector } from "./components/SweatLevelSelector";
 import { LocationSelector } from "./components/LocationSelector";
+import { ActivityStartSelector } from "./components/ActivityStartSelector";
 import { ResultsDisplay } from "./components/ResultsDisplay";
 import { BurnChart } from "./components/BurnChart";
 import { UVChart } from "./components/UVChart";
@@ -35,6 +36,10 @@ import { SunTimer } from "./components/SunTimer";
 import { RelativeTime } from "./components/RelativeTime";
 import { MathExplanation } from "./components/MathExplanation";
 import { SunPositionCard } from "./components/SunPositionCard";
+import {
+	formatActivityStartLabel,
+	resolveActivityStartDate,
+} from "./utils/activity-start";
 
 function App() {
 	const {
@@ -43,6 +48,7 @@ function App() {
 		sweatLevel,
 		geolocation,
 		calculation,
+		activityStart,
 		setCalculation,
 		setGeolocationStatus,
 		setWeather,
@@ -72,7 +78,7 @@ function App() {
 		const input = {
 			weather: geolocation.weather,
 			placeName: geolocation.placeName,
-			currentTime: new Date(),
+			currentTime: resolveActivityStartDate(activityStart),
 			skinType,
 			spfLevel,
 			sweatLevel: sweatLevel ?? DEFAULT_SWEAT_LEVEL,
@@ -87,6 +93,7 @@ function App() {
 		sweatLevel,
 		geolocation.weather,
 		geolocation.placeName,
+		activityStart,
 		setCalculation,
 	]);
 
@@ -108,6 +115,7 @@ function App() {
 	};
 
 	const showSweatLevel = spfLevel !== undefined && spfLevel !== SPFLevel.NONE;
+	const selectedActivityStartTime = resolveActivityStartDate(activityStart);
 
 	return (
 		<div className="min-h-screen bg-orange-50">
@@ -132,7 +140,9 @@ function App() {
 				{/* Steps Accordion */}
 				<Accordion
 					type="multiple"
-					defaultValue={hasPreloadedPrefs ? [] : ["step1", "step2", "step3"]}
+					defaultValue={
+						hasPreloadedPrefs ? [] : ["step1", "step2", "step3", "step4"]
+					}
 					className="space-y-4"
 				>
 					{/* Step 1: Skin Type */}
@@ -262,15 +272,58 @@ function App() {
 							<LocationSelector />
 						</AccordionContent>
 					</AccordionItem>
+
+					{/* Step 4: Start Time */}
+					<AccordionItem
+						value="step4"
+						className="bg-card border-stone-200 shadow-sm rounded-lg mb-4"
+					>
+						<AccordionTrigger className="group px-6 py-4 hover:no-underline">
+							<div className="flex-1 text-left">
+								<StepHeader
+									stepNumber={4}
+									title="When Are You Going Outside?"
+									description="Pick a start time from the usable forecast."
+									isCompleted={true}
+									hideDescription={true}
+								/>
+								<div className="mt-4 ml-12 flex items-center gap-2 group-data-[state=open]:hidden">
+									<Badge variant="outline">
+										{geolocation.weather
+											? formatActivityStartLabel(
+													activityStart,
+													geolocation.weather.timezone,
+												)
+											: "Now"}
+									</Badge>
+								</div>
+							</div>
+						</AccordionTrigger>
+						<AccordionContent className="px-6 pb-6">
+							<ActivityStartSelector />
+						</AccordionContent>
+					</AccordionItem>
 				</Accordion>
 
 				{/* Results */}
 				{calculation && (
 					<div className="mt-8 space-y-6">
 						<div className="flex items-center justify-between">
-							<h2 className="text-2xl font-bold text-slate-800">
-								Safe Sun Exposure Time
-							</h2>
+							<div>
+								<h2 className="text-2xl font-bold text-slate-800">
+									Safe Sun Exposure Time
+								</h2>
+								{geolocation.weather && (
+									<p className="text-sm text-slate-600">
+										For{" "}
+										{formatActivityStartLabel(
+											activityStart,
+											geolocation.weather.timezone,
+										)}{" "}
+										in {geolocation.placeName}
+									</p>
+								)}
+							</div>
 							<div className="flex space-x-2">
 								<Button
 									variant="outline"
@@ -302,6 +355,10 @@ function App() {
 							<UVChart
 								result={calculation}
 								timezone={geolocation.weather?.timezone}
+								startMarkerTime={selectedActivityStartTime}
+								startMarkerLabel={
+									activityStart.mode === "now" ? "Now" : "Start"
+								}
 							/>
 						</div>
 						<SunPositionCard />

--- a/src/components/ActivityStartSelector.tsx
+++ b/src/components/ActivityStartSelector.tsx
@@ -1,0 +1,215 @@
+import { useEffect, useMemo } from "react";
+import { CalendarClock, Clock, SunMedium } from "lucide-react";
+import { haptic } from "ios-haptics";
+import { useAppStore } from "../store";
+import {
+	ACTIVITY_START_STEP_MINUTES,
+	createForecastOffsetStart,
+	formatActivityStartLabel,
+	formatForecastDate,
+	getForecastStartWindow,
+	getPresetOffsetMinutes,
+	resolveActivityStartDate,
+	snapOffsetMinutes,
+} from "../utils/activity-start";
+import { Button } from "./ui/button";
+
+const PRESETS = [
+	{ key: "laterToday", label: "Later today" },
+	{ key: "tomorrowMorning", label: "Tomorrow morning" },
+	{ key: "tomorrowAfternoon", label: "Tomorrow afternoon" },
+] as const;
+
+export function ActivityStartSelector() {
+	const { activityStart, geolocation, setActivityStart } = useAppStore();
+	const weather = geolocation.weather;
+	const renderTimeMs = Date.now();
+
+	const baseTimeMs =
+		activityStart.mode === "forecastOffset"
+			? activityStart.baseTimeMs
+			: renderTimeMs;
+
+	const forecastWindow = useMemo(() => {
+		if (!weather) return undefined;
+		return getForecastStartWindow(weather, baseTimeMs);
+	}, [weather, baseTimeMs]);
+
+	const timezone = weather?.timezone;
+	const selectedOffset =
+		activityStart.mode === "forecastOffset"
+			? activityStart.offsetMinutes
+			: (forecastWindow?.minOffsetMinutes ?? 0);
+	const selectedStepIndex = Math.round(
+		(selectedOffset - (forecastWindow?.minOffsetMinutes ?? 0)) /
+			ACTIVITY_START_STEP_MINUTES,
+	);
+
+	useEffect(() => {
+		if (
+			!weather ||
+			!forecastWindow ||
+			activityStart.mode !== "forecastOffset"
+		) {
+			return;
+		}
+
+		const snappedOffset = snapOffsetMinutes(
+			activityStart.offsetMinutes,
+			forecastWindow,
+		);
+		if (snappedOffset !== activityStart.offsetMinutes) {
+			setActivityStart({
+				...activityStart,
+				offsetMinutes: snappedOffset,
+			});
+		}
+	}, [activityStart, forecastWindow, setActivityStart, weather]);
+
+	if (!weather || !timezone || !forecastWindow) {
+		return (
+			<p className="text-sm text-slate-600">
+				Choose a location first so the forecast timeline can be loaded.
+			</p>
+		);
+	}
+
+	const selectedDate = resolveActivityStartDate(activityStart);
+	const forecastEndLabel = formatForecastDate(
+		forecastWindow.forecastEnd,
+		timezone,
+	);
+	const selectedLabel = formatActivityStartLabel(activityStart, timezone);
+	const placeLabel = geolocation.placeName ?? "Selected location";
+	const sliderStepCount = Math.max(
+		0,
+		Math.floor(
+			(forecastWindow.maxOffsetMinutes - forecastWindow.minOffsetMinutes) /
+				ACTIVITY_START_STEP_MINUTES,
+		),
+	);
+
+	const chooseNow = () => {
+		haptic();
+		setActivityStart({ mode: "now" });
+	};
+
+	const chooseOffset = (offsetMinutes: number) => {
+		haptic();
+		setActivityStart(
+			createForecastOffsetStart(offsetMinutes, weather, renderTimeMs),
+		);
+	};
+
+	const updateStepIndex = (stepIndex: number) => {
+		haptic();
+		const base =
+			activityStart.mode === "forecastOffset"
+				? activityStart.baseTimeMs
+				: renderTimeMs;
+		const offsetMinutes =
+			forecastWindow.minOffsetMinutes + stepIndex * ACTIVITY_START_STEP_MINUTES;
+		setActivityStart(createForecastOffsetStart(offsetMinutes, weather, base));
+	};
+
+	const isNowSelected = activityStart.mode === "now";
+
+	return (
+		<div className="space-y-5">
+			<div className="flex flex-wrap gap-2">
+				<Button
+					type="button"
+					variant={isNowSelected ? "default" : "outline"}
+					onClick={chooseNow}
+				>
+					<Clock className="size-4" />
+					Now
+				</Button>
+				{PRESETS.map((preset) => {
+					const offset = getPresetOffsetMinutes(
+						preset.key,
+						timezone,
+						forecastWindow,
+						renderTimeMs,
+					);
+					const selected =
+						activityStart.mode === "forecastOffset" &&
+						offset !== undefined &&
+						Math.abs(activityStart.offsetMinutes - offset) <
+							ACTIVITY_START_STEP_MINUTES;
+
+					return (
+						<Button
+							key={preset.key}
+							type="button"
+							variant={selected ? "default" : "outline"}
+							onClick={() => offset !== undefined && chooseOffset(offset)}
+							disabled={offset === undefined}
+						>
+							{preset.key === "laterToday" ? (
+								<SunMedium className="size-4" />
+							) : (
+								<CalendarClock className="size-4" />
+							)}
+							{preset.label}
+						</Button>
+					);
+				})}
+			</div>
+
+			<div className="rounded-md border border-stone-200 bg-white/70 p-4">
+				<div className="mb-4 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+					<div>
+						<p className="text-sm font-medium text-slate-700">Start time</p>
+						<p className="text-2xl font-bold tabular-nums text-slate-900">
+							{selectedLabel}
+						</p>
+						<p className="mt-1 text-sm text-slate-500">{placeLabel}</p>
+					</div>
+					<p className="text-sm text-slate-500">
+						Forecast through {forecastEndLabel}
+					</p>
+				</div>
+
+				<input
+					type="range"
+					min={0}
+					max={sliderStepCount}
+					step={1}
+					value={selectedStepIndex}
+					onChange={(event) =>
+						updateStepIndex(Number(event.currentTarget.value))
+					}
+					aria-label="Start exposure time"
+					aria-valuetext={selectedLabel}
+					title=""
+					className="h-2 w-full cursor-pointer appearance-none rounded-full bg-stone-200 accent-amber-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+				/>
+
+				<div className="mt-3 grid grid-cols-3 text-xs text-slate-500">
+					<span>Now</span>
+					<span className="text-center">
+						{formatOffsetLabel(forecastWindow.maxOffsetMinutes / 2)}
+					</span>
+					<span className="text-right">{forecastEndLabel}</span>
+				</div>
+			</div>
+
+			{activityStart.mode === "forecastOffset" && (
+				<p className="sr-only">
+					Planning for {formatForecastDate(selectedDate, timezone)} in{" "}
+					{placeLabel}.
+				</p>
+			)}
+		</div>
+	);
+}
+
+function formatOffsetLabel(offsetMinutes: number): string {
+	const hours = Math.round(offsetMinutes / 60);
+	if (hours < 24) {
+		return `${hours}h`;
+	}
+
+	return `${Math.round(hours / 24)}d`;
+}

--- a/src/components/UVChart.tsx
+++ b/src/components/UVChart.tsx
@@ -39,9 +39,16 @@ ChartJS.register(
 interface UVChartProps {
 	result: CalculationResult;
 	timezone?: string;
+	startMarkerTime?: Date;
+	startMarkerLabel?: string;
 }
 
-export function UVChart({ result, timezone }: UVChartProps) {
+export function UVChart({
+	result,
+	timezone,
+	startMarkerTime,
+	startMarkerLabel = "Now",
+}: UVChartProps) {
 	const { geolocation } = useAppStore();
 
 	// Calculate UV statistics from weather data or fallback to calculation points
@@ -115,8 +122,10 @@ export function UVChart({ result, timezone }: UVChartProps) {
 		return "Extreme";
 	}, []);
 
-	const options = useMemo(
-		() => ({
+	const options = useMemo(() => {
+		const markerTime = startMarkerTime ?? new Date();
+
+		return {
 			responsive: true,
 			maintainAspectRatio: false,
 			interaction: {
@@ -151,13 +160,13 @@ export function UVChart({ result, timezone }: UVChartProps) {
 					annotations: {
 						currentTime: {
 							type: "line" as const,
-							xMin: Date.now(),
-							xMax: Date.now(),
+							xMin: markerTime.getTime(),
+							xMax: markerTime.getTime(),
 							borderColor: "#dc2626", // red-600
 							borderWidth: 2,
 							borderDash: [3, 3],
 							label: {
-								content: "Now",
+								content: startMarkerLabel,
 								enabled: true,
 								position: "start" as const,
 								backgroundColor: "#dc2626",
@@ -230,9 +239,8 @@ export function UVChart({ result, timezone }: UVChartProps) {
 					hoverRadius: 6,
 				},
 			},
-		}),
-		[maxUV, getUVRiskLevel, timezone],
-	);
+		};
+	}, [maxUV, getUVRiskLevel, timezone, startMarkerTime, startMarkerLabel]);
 
 	const getUVRiskColor = (uvIndex: number): string => {
 		if (uvIndex < 3) return "text-green-600";

--- a/src/store.ts
+++ b/src/store.ts
@@ -29,6 +29,7 @@ interface AppStore extends AppState {
 	setGeolocationError: (error: string) => void;
 	setCalculation: (calculation: CalculationResult) => void;
 	clearCalculation: () => void;
+	setActivityStart: (activityStart: AppState["activityStart"]) => void;
 	reset: () => void;
 }
 
@@ -36,6 +37,7 @@ const initialState: AppState = {
 	geolocation: {
 		status: "blank",
 	},
+	activityStart: { mode: "now" },
 };
 
 export const useAppStore = create<AppStore>()(
@@ -102,6 +104,9 @@ export const useAppStore = create<AppStore>()(
 
 			clearCalculation: () =>
 				set((state) => ({ ...state, calculation: undefined })),
+
+			setActivityStart: (activityStart) =>
+				set((state) => ({ ...state, activityStart })),
 
 			reset: () => set(initialState),
 		}),

--- a/src/types.ts
+++ b/src/types.ts
@@ -228,6 +228,14 @@ export interface CalculationResult {
 	advice: string[];
 }
 
+export type ActivityStart =
+	| { mode: "now" }
+	| {
+			mode: "forecastOffset";
+			baseTimeMs: number;
+			offsetMinutes: number;
+	  };
+
 // App State
 export interface AppState {
 	skinType?: FitzpatrickType;
@@ -235,6 +243,7 @@ export interface AppState {
 	sweatLevel?: SweatLevel;
 	geolocation: GeolocationState;
 	calculation?: CalculationResult;
+	activityStart: ActivityStart;
 }
 
 // Constants

--- a/src/utils/activity-start.test.ts
+++ b/src/utils/activity-start.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from "bun:test";
+import type { WeatherData } from "../types";
+import {
+	createForecastOffsetStart,
+	formatActivityStartLabel,
+	getForecastStartWindow,
+	getPresetOffsetMinutes,
+	resolveActivityStartDate,
+} from "./activity-start";
+
+function createWeather(
+	baseTimeMs: number,
+	hours: number,
+	timezone = "America/Denver",
+): WeatherData {
+	const baseSeconds = Math.floor(baseTimeMs / 1000);
+
+	return {
+		current: {
+			dt: baseSeconds,
+			temp: 75,
+			uvi: 5,
+			weather: [
+				{ id: 800, main: "Clear", description: "clear sky", icon: "01d" },
+			],
+		},
+		hourly: Array.from({ length: hours }, (_, index) => ({
+			dt: baseSeconds + index * 3600,
+			temp: 75,
+			uvi: 5,
+			weather: [
+				{ id: 800, main: "Clear", description: "clear sky", icon: "01d" },
+			],
+		})),
+		elevation: 0,
+		sunrise: new Date(baseTimeMs).toISOString(),
+		sunset: new Date(baseTimeMs + 12 * 3600 * 1000).toISOString(),
+		nextSunrise: new Date(baseTimeMs + 24 * 3600 * 1000).toISOString(),
+		timezone,
+	};
+}
+
+describe("activity start utilities", () => {
+	it("resolves planned starts from a session base time without drifting", () => {
+		const baseTimeMs = Date.parse("2026-06-15T16:00:00Z");
+		const activityStart = {
+			mode: "forecastOffset" as const,
+			baseTimeMs,
+			offsetMinutes: 180,
+		};
+
+		expect(resolveActivityStartDate(activityStart).toISOString()).toBe(
+			"2026-06-15T19:00:00.000Z",
+		);
+	});
+
+	it("limits slider range to the smaller of forecast coverage and 48 hours", () => {
+		const baseTimeMs = Date.parse("2026-06-15T16:00:00Z");
+		const weather = createWeather(baseTimeMs, 72);
+
+		const window = getForecastStartWindow(weather, baseTimeMs);
+
+		expect(window.minOffsetMinutes).toBe(0);
+		expect(window.maxOffsetMinutes).toBe(48 * 60);
+	});
+
+	it("snaps selected offsets to 30 minute forecast increments", () => {
+		const baseTimeMs = Date.parse("2026-06-15T16:00:00Z");
+		const weather = createWeather(baseTimeMs, 24);
+
+		const activityStart = createForecastOffsetStart(74, weather, baseTimeMs);
+
+		expect(activityStart).toEqual({
+			mode: "forecastOffset",
+			baseTimeMs,
+			offsetMinutes: 60,
+		});
+	});
+
+	it("snaps from off-boundary current times to actual wall-clock half hours", () => {
+		const baseTimeMs = Date.parse("2026-06-15T21:07:00Z"); // 3:07 PM Denver
+		const weather = createWeather(baseTimeMs, 24);
+
+		const window = getForecastStartWindow(weather, baseTimeMs);
+		const activityStart = createForecastOffsetStart(
+			window.minOffsetMinutes,
+			weather,
+			baseTimeMs,
+		);
+
+		expect(resolveActivityStartDate(activityStart).toISOString()).toBe(
+			"2026-06-15T21:30:00.000Z",
+		);
+		expect(
+			formatActivityStartLabel(
+				activityStart,
+				"America/Denver",
+				new Date(baseTimeMs),
+			),
+		).toBe("Today 3:30 PM");
+	});
+
+	it("formats selected starts in the forecast timezone", () => {
+		const baseTimeMs = Date.parse("2026-06-15T16:00:00Z");
+		const activityStart = {
+			mode: "forecastOffset" as const,
+			baseTimeMs,
+			offsetMinutes: 150,
+		};
+
+		expect(
+			formatActivityStartLabel(
+				activityStart,
+				"America/Denver",
+				new Date(baseTimeMs),
+			),
+		).toBe("Today 12:30 PM");
+	});
+
+	it("creates tomorrow presets in the forecast timezone", () => {
+		const baseTimeMs = Date.parse("2026-06-15T22:00:00Z"); // 4 PM Denver
+		const weather = createWeather(baseTimeMs, 48);
+		const window = getForecastStartWindow(weather, baseTimeMs);
+
+		const offset = getPresetOffsetMinutes(
+			"tomorrowMorning",
+			"America/Denver",
+			window,
+			baseTimeMs,
+		);
+
+		expect(offset).toBe(17 * 60);
+	});
+});

--- a/src/utils/activity-start.ts
+++ b/src/utils/activity-start.ts
@@ -1,0 +1,208 @@
+import { TZDate } from "@date-fns/tz";
+import type { ActivityStart, WeatherData } from "../types";
+import { formatInTimeZone } from "./timezone";
+
+export const ACTIVITY_START_STEP_MINUTES = 30;
+export const ACTIVITY_START_MAX_HOURS = 48;
+
+const MINUTE_MS = 60 * 1000;
+const HOUR_MS = 60 * MINUTE_MS;
+
+export interface ForecastStartWindow {
+	baseTimeMs: number;
+	minOffsetMinutes: number;
+	maxOffsetMinutes: number;
+	forecastEnd: Date;
+	hasUsableForecast: boolean;
+}
+
+export function resolveActivityStartDate(
+	activityStart: ActivityStart,
+	now = new Date(),
+): Date {
+	if (activityStart.mode === "now") {
+		return now;
+	}
+
+	return new Date(
+		activityStart.baseTimeMs + activityStart.offsetMinutes * MINUTE_MS,
+	);
+}
+
+export function getForecastStartWindow(
+	weather: WeatherData,
+	baseTimeMs = Date.now(),
+): ForecastStartWindow {
+	const firstForecastMs = weather.hourly[0]?.dt
+		? weather.hourly[0].dt * 1000
+		: baseTimeMs;
+	const lastHourly = weather.hourly.at(-1);
+	const lastForecastMs = lastHourly ? lastHourly.dt * 1000 : baseTimeMs;
+	const stepMs = ACTIVITY_START_STEP_MINUTES * MINUTE_MS;
+	const minMs = Math.max(baseTimeMs, firstForecastMs);
+	const maxMs = Math.min(
+		baseTimeMs + ACTIVITY_START_MAX_HOURS * HOUR_MS,
+		lastForecastMs,
+	);
+
+	const minOffsetMinutes = Math.max(
+		0,
+		Math.ceil(minMs / stepMs) * ACTIVITY_START_STEP_MINUTES -
+			baseTimeMs / MINUTE_MS,
+	);
+	const maxOffsetMinutes = Math.max(
+		minOffsetMinutes,
+		Math.floor(maxMs / stepMs) * ACTIVITY_START_STEP_MINUTES -
+			baseTimeMs / MINUTE_MS,
+	);
+
+	return {
+		baseTimeMs,
+		minOffsetMinutes,
+		maxOffsetMinutes,
+		forecastEnd: new Date(maxMs),
+		hasUsableForecast: maxMs > minMs,
+	};
+}
+
+export function snapOffsetMinutes(
+	offsetMinutes: number,
+	window: ForecastStartWindow,
+): number {
+	const stepMs = ACTIVITY_START_STEP_MINUTES * MINUTE_MS;
+	const targetMs = window.baseTimeMs + offsetMinutes * MINUTE_MS;
+	const snappedTargetMs = Math.round(targetMs / stepMs) * stepMs;
+	const snapped = (snappedTargetMs - window.baseTimeMs) / MINUTE_MS;
+
+	return Math.min(
+		window.maxOffsetMinutes,
+		Math.max(window.minOffsetMinutes, snapped),
+	);
+}
+
+export function createForecastOffsetStart(
+	offsetMinutes: number,
+	weather: WeatherData,
+	baseTimeMs = Date.now(),
+): ActivityStart {
+	return {
+		mode: "forecastOffset",
+		baseTimeMs,
+		offsetMinutes: snapOffsetMinutes(
+			offsetMinutes,
+			getForecastStartWindow(weather, baseTimeMs),
+		),
+	};
+}
+
+export function formatActivityStartLabel(
+	activityStart: ActivityStart,
+	timezone: string,
+	now = new Date(),
+): string {
+	if (activityStart.mode === "now") {
+		return "Now";
+	}
+
+	return formatForecastDate(
+		resolveActivityStartDate(activityStart, now),
+		timezone,
+		now,
+	);
+}
+
+export function formatForecastDate(
+	date: Date,
+	timezone: string,
+	now = new Date(),
+): string {
+	const zonedDate = new TZDate(date.getTime(), timezone);
+	const zonedNow = new TZDate(now.getTime(), timezone);
+	const dayDiff =
+		startOfDay(zonedDate, timezone).getTime() -
+		startOfDay(zonedNow, timezone).getTime();
+	const dayLabel =
+		dayDiff === 0
+			? "Today"
+			: dayDiff === 24 * HOUR_MS
+				? "Tomorrow"
+				: formatInTimeZone(date, timezone, "EEE");
+
+	return `${dayLabel} ${formatInTimeZone(date, timezone, "h:mm a")}`;
+}
+
+export function getPresetOffsetMinutes(
+	preset: "laterToday" | "tomorrowMorning" | "tomorrowAfternoon",
+	timezone: string,
+	window: ForecastStartWindow,
+	baseTimeMs = Date.now(),
+): number | undefined {
+	const base = new TZDate(baseTimeMs, timezone);
+	let targetMs: number;
+
+	if (preset === "laterToday") {
+		targetMs =
+			Math.ceil(
+				(baseTimeMs + 2 * HOUR_MS) / (ACTIVITY_START_STEP_MINUTES * MINUTE_MS),
+			) *
+			ACTIVITY_START_STEP_MINUTES *
+			MINUTE_MS;
+
+		if (!isSameZonedDay(new Date(targetMs), base, timezone)) {
+			return undefined;
+		}
+	} else {
+		const targetHour = preset === "tomorrowMorning" ? 9 : 13;
+		targetMs = new TZDate(
+			base.getFullYear(),
+			base.getMonth(),
+			base.getDate() + 1,
+			targetHour,
+			0,
+			0,
+			timezone,
+		).getTime();
+	}
+
+	const offsetMinutes = (targetMs - baseTimeMs) / MINUTE_MS;
+	const snapped = snapOffsetMinutes(offsetMinutes, window);
+
+	if (snapped < window.minOffsetMinutes || snapped > window.maxOffsetMinutes) {
+		return undefined;
+	}
+
+	const snappedMs = baseTimeMs + snapped * MINUTE_MS;
+	if (
+		Math.abs(snappedMs - targetMs) >
+		ACTIVITY_START_STEP_MINUTES * MINUTE_MS
+	) {
+		return undefined;
+	}
+
+	return snapped;
+}
+
+function startOfDay(date: TZDate, timezone: string): Date {
+	return new TZDate(
+		date.getFullYear(),
+		date.getMonth(),
+		date.getDate(),
+		0,
+		0,
+		0,
+		timezone,
+	);
+}
+
+function isSameZonedDay(
+	date: Date,
+	zonedBase: TZDate,
+	timezone: string,
+): boolean {
+	const zonedDate = new TZDate(date.getTime(), timezone);
+	return (
+		zonedDate.getFullYear() === zonedBase.getFullYear() &&
+		zonedDate.getMonth() === zonedBase.getMonth() &&
+		zonedDate.getDate() === zonedBase.getDate()
+	);
+}


### PR DESCRIPTION
## Summary
- Add a forecast-backed start time selector with quick presets and 30-minute snapped timeline control
- Use the selected start time for burn calculations and the UV chart start marker
- Keep trip timing out of persisted preferences and cover snapping/timezone behavior with tests

## Verification
- `bun run check`
- `bun test`
- `bun run build`