### PR TITLE
Add shared shadcn-style Slider and fix haptics on activity start slider

### DIFF
--- a/src/components/ActivityStartSelector.tsx
+++ b/src/components/ActivityStartSelector.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import { CalendarClock, Clock, SunMedium } from "lucide-react";
 import { haptic } from "ios-haptics";
 import { useAppStore } from "../store";
@@ -14,6 +14,8 @@ import {
 } from "../utils/activity-start";
 import { Button } from "./ui/button";
 import { Slider } from "./ui/slider";
+
+const HAPTIC_STEP_INTERVAL_MS = 35;
 
 const PRESETS = [
 	{ key: "laterToday", label: "Later today" },
@@ -45,6 +47,12 @@ export function ActivityStartSelector() {
 		(selectedOffset - (forecastWindow?.minOffsetMinutes ?? 0)) /
 			ACTIVITY_START_STEP_MINUTES,
 	);
+	const lastHapticStepRef = useRef<number | undefined>(undefined);
+	const lastHapticMsRef = useRef(0);
+
+	useEffect(() => {
+		lastHapticStepRef.current = selectedStepIndex;
+	}, [selectedStepIndex]);
 
 	useEffect(() => {
 		if (
@@ -117,7 +125,16 @@ export function ActivityStartSelector() {
 			return;
 		}
 
-		haptic();
+		if (lastHapticStepRef.current !== stepIndex) {
+			const now = performance.now();
+			if (now - lastHapticMsRef.current >= HAPTIC_STEP_INTERVAL_MS) {
+				haptic();
+				lastHapticMsRef.current = now;
+			}
+
+			lastHapticStepRef.current = stepIndex;
+		}
+
 		setActivityStart(createForecastOffsetStart(offsetMinutes, weather, base));
 	};
 

--- a/src/components/ActivityStartSelector.tsx
+++ b/src/components/ActivityStartSelector.tsx
@@ -13,6 +13,7 @@ import {
 	snapOffsetMinutes,
 } from "../utils/activity-start";
 import { Button } from "./ui/button";
+import { Slider } from "./ui/slider";
 
 const PRESETS = [
 	{ key: "laterToday", label: "Later today" },
@@ -102,13 +103,21 @@ export function ActivityStartSelector() {
 	};
 
 	const updateStepIndex = (stepIndex: number) => {
-		haptic();
 		const base =
 			activityStart.mode === "forecastOffset"
 				? activityStart.baseTimeMs
 				: renderTimeMs;
 		const offsetMinutes =
 			forecastWindow.minOffsetMinutes + stepIndex * ACTIVITY_START_STEP_MINUTES;
+
+		if (
+			activityStart.mode === "forecastOffset" &&
+			activityStart.offsetMinutes === offsetMinutes
+		) {
+			return;
+		}
+
+		haptic();
 		setActivityStart(createForecastOffsetStart(offsetMinutes, weather, base));
 	};
 
@@ -171,19 +180,15 @@ export function ActivityStartSelector() {
 					</p>
 				</div>
 
-				<input
-					type="range"
+				<Slider
 					min={0}
 					max={sliderStepCount}
 					step={1}
-					value={selectedStepIndex}
-					onChange={(event) =>
-						updateStepIndex(Number(event.currentTarget.value))
-					}
+					value={[selectedStepIndex]}
+					onValueChange={(value) => updateStepIndex(value[0] ?? 0)}
 					aria-label="Start exposure time"
 					aria-valuetext={selectedLabel}
 					title=""
-					className="h-2 w-full cursor-pointer appearance-none rounded-full bg-stone-200 accent-amber-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
 				/>
 
 				<div className="mt-3 grid grid-cols-3 text-xs text-slate-500">

--- a/src/components/ui/slider.tsx
+++ b/src/components/ui/slider.tsx
@@ -4,7 +4,7 @@ import { cn } from "@/lib/utils";
 
 type SliderProps = Omit<
 	React.InputHTMLAttributes<HTMLInputElement>,
-	"value" | "defaultValue" | "min" | "max" | "step" | "onChange"
+	"value" | "defaultValue" | "min" | "max" | "step" | "onInput" | "onChange"
 > & {
 	value?: number[];
 	defaultValue?: number[];
@@ -39,7 +39,7 @@ const Slider = React.forwardRef<HTMLInputElement, SliderProps>(
 				max={max}
 				step={step}
 				value={currentValue}
-				onInput={(event) => {
+				onChange={(event) => {
 					onValueChange?.([Number(event.currentTarget.value)]);
 				}}
 				className={cn(

--- a/src/components/ui/slider.tsx
+++ b/src/components/ui/slider.tsx
@@ -1,0 +1,57 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+type SliderProps = Omit<
+	React.InputHTMLAttributes<HTMLInputElement>,
+	"value" | "defaultValue" | "min" | "max" | "step" | "onChange"
+> & {
+	value?: number[];
+	defaultValue?: number[];
+	min?: number;
+	max?: number;
+	step?: number;
+	onValueChange?: (value: number[]) => void;
+};
+
+const Slider = React.forwardRef<HTMLInputElement, SliderProps>(
+	(
+		{
+			className,
+			value,
+			defaultValue,
+			min = 0,
+			max = 100,
+			step = 1,
+			onValueChange,
+			...props
+		},
+		ref,
+	) => {
+		const currentValue = value?.[0] ?? defaultValue?.[0] ?? min;
+
+		return (
+			<input
+				ref={ref}
+				type="range"
+				data-slot="slider"
+				min={min}
+				max={max}
+				step={step}
+				value={currentValue}
+				onInput={(event) => {
+					onValueChange?.([Number(event.currentTarget.value)]);
+				}}
+				className={cn(
+					"h-2 w-full cursor-pointer appearance-none rounded-full bg-stone-200 accent-amber-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+					className,
+				)}
+				{...props}
+			/>
+		);
+	},
+);
+
+Slider.displayName = "Slider";
+
+export { Slider };


### PR DESCRIPTION
### Motivation
- Make the activity-start control match the app's shadcn-style UI primitives and avoid mixing a raw `<input type="range">` with other components. 
- Prevent noisy or missing haptic feedback by only firing haptics when the selected slider step actually changes.

### Description
- Added a reusable `Slider` component at `src/components/ui/slider.tsx` that exposes a shadcn-style API (`value`/`defaultValue` as arrays and `onValueChange`) and applies the existing Tailwind styling.
- Replaced the inline `input type="range"` in `ActivityStartSelector` with the new `Slider` and wired `onValueChange` to the selector logic (`src/components/ActivityStartSelector.tsx`).
- Adjusted `updateStepIndex` so it early-returns when the computed offset is unchanged and only calls `haptic()` when a real change occurs.
- Chose to implement a local shadcn-style slider instead of adding an external `@base-ui` package after package installation attempts were blocked, preserving a consistent component API.

### Testing
- Ran `bun test`, all tests passed (33 passed, 0 failed). 
- Ran `bun run check`, which reported existing Biome/Tailwind parser configuration errors unrelated to these changes (no code regressions introduced by this PR).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0116acdc083259ec84cb5d318aee8)