### PR TITLE
Add Google Weather preview provider

### DIFF
--- a/api/google-weather.ts
+++ b/api/google-weather.ts
@@ -1,0 +1,434 @@
+import { TZDate } from "@date-fns/tz";
+
+type WeatherOverview = {
+	id: number;
+	main: string;
+	description: string;
+	icon: string;
+};
+
+type WeatherData = {
+	current: {
+		dt: number;
+		temp: number;
+		uvi: number;
+		weather: WeatherOverview[];
+	};
+	hourly: Array<{
+		dt: number;
+		temp: number;
+		uvi: number;
+		weather: WeatherOverview[];
+	}>;
+	elevation: number;
+	aqi?: {
+		us_aqi: number;
+	};
+	sunrise: string;
+	sunset: string;
+	nextSunrise: string;
+	timezone: string;
+};
+
+type GoogleForecastHour = {
+	interval?: {
+		startTime?: string;
+	};
+	weatherCondition?: {
+		iconBaseUri?: string;
+		type?: string;
+		description?: {
+			text?: string;
+		};
+	};
+	temperature?: {
+		degrees?: number;
+	};
+	uvIndex?: number;
+};
+
+type GoogleHourlyResponse = {
+	forecastHours?: GoogleForecastHour[];
+	timeZone?: {
+		id?: string;
+	};
+};
+
+type OpenMeteoMetadataResponse = {
+	elevation?: number;
+	timezone?: string;
+	daily?: {
+		sunrise?: string[];
+		sunset?: string[];
+	};
+};
+
+type OpenMeteoAqiResponse = {
+	current?: {
+		us_aqi?: number;
+	};
+};
+
+type CacheEntry = {
+	expiresAt: number;
+	body: WeatherData;
+};
+
+type RateLimitEntry = {
+	windowStart: number;
+	count: number;
+};
+
+const GOOGLE_WEATHER_BASE_URL =
+	"https://weather.googleapis.com/v1/forecast/hours:lookup";
+const OPEN_METEO_FORECAST_URL = "https://api.open-meteo.com/v1/forecast";
+const OPEN_METEO_AQI_URL =
+	"https://air-quality-api.open-meteo.com/v1/air-quality";
+const CACHE_TTL_MS = 30 * 60 * 1000;
+const RATE_LIMIT_WINDOW_MS = 60 * 60 * 1000;
+const RATE_LIMIT_MAX = 30;
+
+const globalRuntime = globalThis as typeof globalThis & {
+	__sunburnGoogleWeatherCache?: Map<string, CacheEntry>;
+	__sunburnGoogleWeatherRateLimit?: Map<string, RateLimitEntry>;
+};
+
+const weatherCache =
+	globalRuntime.__sunburnGoogleWeatherCache ?? new Map<string, CacheEntry>();
+const rateLimit =
+	globalRuntime.__sunburnGoogleWeatherRateLimit ??
+	new Map<string, RateLimitEntry>();
+
+globalRuntime.__sunburnGoogleWeatherCache = weatherCache;
+globalRuntime.__sunburnGoogleWeatherRateLimit = rateLimit;
+
+export default {
+	async fetch(request: Request): Promise<Response> {
+		if (request.method !== "GET") {
+			return jsonResponse({ error: "Method not allowed" }, 405);
+		}
+
+		if (!isAllowedGoogleTestRequest(request)) {
+			return jsonResponse({ error: "Google weather test route required" }, 403);
+		}
+
+		const rateLimitResponse = checkRateLimit(request);
+		if (rateLimitResponse) {
+			return rateLimitResponse;
+		}
+
+		const apiKey = process.env.GOOGLE_MAPS_API_KEY;
+		if (!apiKey) {
+			return jsonResponse({ error: "Missing GOOGLE_MAPS_API_KEY" }, 500);
+		}
+
+		const url = new URL(request.url);
+		const latitude = parseCoordinate(url.searchParams.get("latitude"), -90, 90);
+		const longitude = parseCoordinate(
+			url.searchParams.get("longitude"),
+			-180,
+			180,
+		);
+
+		if (latitude === undefined || longitude === undefined) {
+			return jsonResponse(
+				{ error: "Valid latitude and longitude are required" },
+				400,
+			);
+		}
+
+		const roundedLatitude = roundCoordinate(latitude);
+		const roundedLongitude = roundCoordinate(longitude);
+		const cacheKey = [
+			"google-weather-v1",
+			roundedLatitude,
+			roundedLongitude,
+			new Date().toISOString().slice(0, 13),
+		].join(":");
+
+		const cached = weatherCache.get(cacheKey);
+		if (cached && cached.expiresAt > Date.now()) {
+			return weatherResponse(cached.body, "HIT");
+		}
+
+		try {
+			const [googleWeather, metadata, aqi] = await Promise.all([
+				fetchGoogleHourlyWeather(apiKey, roundedLatitude, roundedLongitude),
+				fetchOpenMeteoMetadata(roundedLatitude, roundedLongitude),
+				fetchOpenMeteoAqi(roundedLatitude, roundedLongitude),
+			]);
+			const weather = normalizeWeatherData(googleWeather, metadata, aqi);
+
+			weatherCache.set(cacheKey, {
+				expiresAt: Date.now() + CACHE_TTL_MS,
+				body: weather,
+			});
+
+			return weatherResponse(weather, "MISS");
+		} catch (error) {
+			return jsonResponse(
+				{
+					error:
+						error instanceof Error
+							? error.message
+							: "Failed to fetch Google weather",
+				},
+				502,
+			);
+		}
+	},
+};
+
+function isAllowedGoogleTestRequest(request: Request): boolean {
+	if (process.env.NODE_ENV !== "production") {
+		return true;
+	}
+
+	const referer = request.headers.get("referer");
+	if (!referer) {
+		return false;
+	}
+
+	try {
+		return new URL(referer).pathname.replace(/\/+$/, "") === "/google";
+	} catch {
+		return false;
+	}
+}
+
+function checkRateLimit(request: Request): Response | undefined {
+	const ipAddress = getIpAddress(request);
+	const now = Date.now();
+	const entry = rateLimit.get(ipAddress);
+
+	if (!entry || now - entry.windowStart >= RATE_LIMIT_WINDOW_MS) {
+		rateLimit.set(ipAddress, { windowStart: now, count: 1 });
+		return undefined;
+	}
+
+	entry.count += 1;
+	if (entry.count > RATE_LIMIT_MAX) {
+		return jsonResponse(
+			{ error: "Too many Google weather requests. Please try again later." },
+			429,
+			{
+				"Retry-After": Math.ceil(
+					(RATE_LIMIT_WINDOW_MS - (now - entry.windowStart)) / 1000,
+				).toString(),
+			},
+		);
+	}
+
+	return undefined;
+}
+
+function getIpAddress(request: Request): string {
+	return (
+		request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
+		request.headers.get("x-real-ip") ||
+		"unknown"
+	);
+}
+
+function parseCoordinate(
+	value: string | null,
+	min: number,
+	max: number,
+): number | undefined {
+	if (!value) {
+		return undefined;
+	}
+
+	const coordinate = Number(value);
+	if (!Number.isFinite(coordinate) || coordinate < min || coordinate > max) {
+		return undefined;
+	}
+
+	return coordinate;
+}
+
+function roundCoordinate(coordinate: number): number {
+	return Number(coordinate.toFixed(3));
+}
+
+async function fetchGoogleHourlyWeather(
+	apiKey: string,
+	latitude: number,
+	longitude: number,
+): Promise<GoogleHourlyResponse> {
+	const url = new URL(GOOGLE_WEATHER_BASE_URL);
+	url.search = new URLSearchParams({
+		key: apiKey,
+		"location.latitude": latitude.toString(),
+		"location.longitude": longitude.toString(),
+		unitsSystem: "IMPERIAL",
+		hours: "24",
+		pageSize: "24",
+		languageCode: "en",
+	}).toString();
+
+	const response = await fetch(url);
+	if (!response.ok) {
+		throw new Error(
+			`Google Weather API error: ${response.status} ${response.statusText}`,
+		);
+	}
+
+	return response.json();
+}
+
+async function fetchOpenMeteoMetadata(
+	latitude: number,
+	longitude: number,
+): Promise<OpenMeteoMetadataResponse> {
+	const url = new URL(OPEN_METEO_FORECAST_URL);
+	url.search = new URLSearchParams({
+		latitude: latitude.toString(),
+		longitude: longitude.toString(),
+		daily: "sunrise,sunset",
+		forecast_days: "2",
+		timezone: "auto",
+	}).toString();
+
+	const response = await fetch(url);
+	if (!response.ok) {
+		throw new Error(
+			`Open-Meteo metadata error: ${response.status} ${response.statusText}`,
+		);
+	}
+
+	return response.json();
+}
+
+async function fetchOpenMeteoAqi(
+	latitude: number,
+	longitude: number,
+): Promise<OpenMeteoAqiResponse | undefined> {
+	const url = new URL(OPEN_METEO_AQI_URL);
+	url.search = new URLSearchParams({
+		latitude: latitude.toString(),
+		longitude: longitude.toString(),
+		current: "us_aqi",
+		domains: "cams_global",
+	}).toString();
+
+	const response = await fetch(url);
+	if (!response.ok) {
+		return undefined;
+	}
+
+	return response.json();
+}
+
+function normalizeWeatherData(
+	googleWeather: GoogleHourlyResponse,
+	metadata: OpenMeteoMetadataResponse,
+	aqi: OpenMeteoAqiResponse | undefined,
+): WeatherData {
+	const hourly = (googleWeather.forecastHours ?? []).flatMap((hour) => {
+		const startTime = hour.interval?.startTime;
+		const temperature = hour.temperature?.degrees;
+		const uvIndex = hour.uvIndex;
+
+		if (
+			!startTime ||
+			typeof temperature !== "number" ||
+			typeof uvIndex !== "number"
+		) {
+			return [];
+		}
+
+		return [
+			{
+				dt: Math.floor(Date.parse(startTime) / 1000),
+				temp: temperature,
+				uvi: uvIndex,
+				weather: [normalizeWeatherOverview(hour)],
+			},
+		];
+	});
+
+	const current = hourly[0];
+	if (!current) {
+		throw new Error("Invalid Google weather data received");
+	}
+
+	const timezone = googleWeather.timeZone?.id || metadata.timezone;
+	if (!timezone) {
+		throw new Error("Missing weather timezone");
+	}
+
+	const sunrise = metadata.daily?.sunrise?.[0];
+	const sunset = metadata.daily?.sunset?.[0];
+	const nextSunrise = metadata.daily?.sunrise?.[1];
+	if (!sunrise || !sunset || !nextSunrise) {
+		throw new Error("Missing sunrise or sunset metadata");
+	}
+
+	return {
+		current,
+		hourly,
+		elevation: metadata.elevation ?? 0,
+		aqi:
+			typeof aqi?.current?.us_aqi === "number"
+				? { us_aqi: Math.round(aqi.current.us_aqi) }
+				: undefined,
+		sunrise: new Date(parseLocationTime(sunrise, timezone)).toISOString(),
+		sunset: new Date(parseLocationTime(sunset, timezone)).toISOString(),
+		nextSunrise: new Date(
+			parseLocationTime(nextSunrise, timezone),
+		).toISOString(),
+		timezone,
+	};
+}
+
+function parseLocationTime(timeStr: string, timezone: string): number {
+	const [datePart, timePart] = timeStr.split("T");
+	const [year, month, day] = datePart.split("-").map(Number);
+	const [hour, minute] = (timePart ?? "00:00").split(":").map(Number);
+
+	return new TZDate(year, month - 1, day, hour, minute, 0, timezone).getTime();
+}
+
+function normalizeWeatherOverview(hour: GoogleForecastHour): WeatherOverview {
+	const type = hour.weatherCondition?.type ?? "UNKNOWN";
+	const description =
+		hour.weatherCondition?.description?.text ?? type.replaceAll("_", " ");
+
+	return {
+		id: 800,
+		main: toTitleCase(type.replaceAll("_", " ").toLowerCase()),
+		description,
+		icon: hour.weatherCondition?.iconBaseUri ?? "",
+	};
+}
+
+function toTitleCase(value: string): string {
+	return value.replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+function weatherResponse(
+	body: WeatherData,
+	cacheStatus: "HIT" | "MISS",
+): Response {
+	return jsonResponse(body, 200, {
+		"Cache-Control":
+			"public, max-age=0, s-maxage=1800, stale-while-revalidate=1800",
+		"X-Weather-Provider": "google",
+		"X-Cache-Status": cacheStatus,
+	});
+}
+
+function jsonResponse(
+	body: unknown,
+	status: number,
+	headers?: Record<string, string>,
+): Response {
+	return Response.json(body, {
+		status,
+		headers: {
+			...headers,
+			"Content-Type": "application/json",
+		},
+	});
+}

--- a/api/google-weather.ts
+++ b/api/google-weather.ts
@@ -85,7 +85,8 @@ const GOOGLE_WEATHER_BASE_URL =
 const OPEN_METEO_FORECAST_URL = "https://api.open-meteo.com/v1/forecast";
 const OPEN_METEO_AQI_URL =
 	"https://air-quality-api.open-meteo.com/v1/air-quality";
-const FORECAST_HOURS = 72;
+const FORECAST_DAYS = 3;
+const MAX_GOOGLE_FORECAST_HOURS = 72;
 const CACHE_TTL_MS = 5 * 60 * 1000;
 const RATE_LIMIT_WINDOW_MS = 60 * 60 * 1000;
 const RATE_LIMIT_MAX = 30;
@@ -272,10 +273,10 @@ async function fetchGoogleHourlyWeather(
 		timeZone ??= page.timeZone;
 		forecastHours.push(...(page.forecastHours ?? []));
 		nextPageToken = page.nextPageToken;
-	} while (nextPageToken && forecastHours.length < FORECAST_HOURS);
+	} while (nextPageToken && forecastHours.length < MAX_GOOGLE_FORECAST_HOURS);
 
 	return {
-		forecastHours: forecastHours.slice(0, FORECAST_HOURS),
+		forecastHours: forecastHours.slice(0, MAX_GOOGLE_FORECAST_HOURS),
 		timeZone,
 	};
 }
@@ -292,7 +293,7 @@ async function fetchGoogleHourlyWeatherPage(
 		"location.latitude": latitude.toString(),
 		"location.longitude": longitude.toString(),
 		unitsSystem: "IMPERIAL",
-		hours: FORECAST_HOURS.toString(),
+		hours: MAX_GOOGLE_FORECAST_HOURS.toString(),
 		pageSize: "24",
 		languageCode: "en",
 	});
@@ -322,7 +323,7 @@ async function fetchOpenMeteoMetadata(
 		latitude: latitude.toString(),
 		longitude: longitude.toString(),
 		daily: "sunrise,sunset",
-		forecast_days: "2",
+		forecast_days: FORECAST_DAYS.toString(),
 		timezone: "auto",
 	}).toString();
 
@@ -361,6 +362,11 @@ function normalizeWeatherData(
 	metadata: OpenMeteoMetadataResponse,
 	aqi: OpenMeteoAqiResponse | undefined,
 ): WeatherData {
+	const timezone = googleWeather.timeZone?.id || metadata.timezone;
+	if (!timezone) {
+		throw new Error("Missing weather timezone");
+	}
+
 	const hourly = (googleWeather.forecastHours ?? []).flatMap((hour) => {
 		const startTime = hour.interval?.startTime;
 		const temperature = hour.temperature?.degrees;
@@ -383,15 +389,11 @@ function normalizeWeatherData(
 			},
 		];
 	});
+	const filteredHourly = filterToForecastDays(hourly, timezone);
 
-	const current = hourly[0];
+	const current = filteredHourly[0];
 	if (!current) {
 		throw new Error("Invalid Google weather data received");
-	}
-
-	const timezone = googleWeather.timeZone?.id || metadata.timezone;
-	if (!timezone) {
-		throw new Error("Missing weather timezone");
 	}
 
 	const sunrise = metadata.daily?.sunrise?.[0];
@@ -403,7 +405,7 @@ function normalizeWeatherData(
 
 	return {
 		current,
-		hourly,
+		hourly: filteredHourly,
 		elevation: metadata.elevation ?? 0,
 		aqi:
 			typeof aqi?.current?.us_aqi === "number"
@@ -416,6 +418,52 @@ function normalizeWeatherData(
 		).toISOString(),
 		timezone,
 	};
+}
+
+function filterToForecastDays(
+	hourly: WeatherData["hourly"],
+	timezone: string,
+): WeatherData["hourly"] {
+	const firstHour = hourly[0];
+	if (!firstHour) {
+		return [];
+	}
+
+	const startDay = getDateKeyInTimezone(firstHour.dt, timezone);
+	const includedDays = new Set<string>();
+	let lastIncludedDay = startDay;
+
+	for (const hour of hourly) {
+		const day = getDateKeyInTimezone(hour.dt, timezone);
+		if (!includedDays.has(day)) {
+			if (includedDays.size >= FORECAST_DAYS) {
+				break;
+			}
+			includedDays.add(day);
+			lastIncludedDay = day;
+		}
+	}
+
+	return hourly.filter((hour) => {
+		const day = getDateKeyInTimezone(hour.dt, timezone);
+		return day >= startDay && day <= lastIncludedDay;
+	});
+}
+
+function getDateKeyInTimezone(
+	timestampSeconds: number,
+	timezone: string,
+): string {
+	const parts = new Intl.DateTimeFormat("en-US", {
+		timeZone: timezone,
+		year: "numeric",
+		month: "2-digit",
+		day: "2-digit",
+	}).formatToParts(new Date(timestampSeconds * 1000));
+	const part = (type: string) =>
+		parts.find((datePart) => datePart.type === type)?.value;
+
+	return `${part("year")}-${part("month")}-${part("day")}`;
 }
 
 function parseLocationTime(timeStr: string, timezone: string): number {

--- a/api/google-weather.ts
+++ b/api/google-weather.ts
@@ -52,6 +52,7 @@ type GoogleHourlyResponse = {
 	timeZone?: {
 		id?: string;
 	};
+	nextPageToken?: string;
 };
 
 type OpenMeteoMetadataResponse = {
@@ -84,6 +85,7 @@ const GOOGLE_WEATHER_BASE_URL =
 const OPEN_METEO_FORECAST_URL = "https://api.open-meteo.com/v1/forecast";
 const OPEN_METEO_AQI_URL =
 	"https://air-quality-api.open-meteo.com/v1/air-quality";
+const FORECAST_HOURS = 72;
 const CACHE_TTL_MS = 30 * 60 * 1000;
 const RATE_LIMIT_WINDOW_MS = 60 * 60 * 1000;
 const RATE_LIMIT_MAX = 30;
@@ -256,16 +258,50 @@ async function fetchGoogleHourlyWeather(
 	latitude: number,
 	longitude: number,
 ): Promise<GoogleHourlyResponse> {
+	let nextPageToken: string | undefined;
+	let timeZone: GoogleHourlyResponse["timeZone"];
+	const forecastHours: GoogleForecastHour[] = [];
+
+	do {
+		const page = await fetchGoogleHourlyWeatherPage(
+			apiKey,
+			latitude,
+			longitude,
+			nextPageToken,
+		);
+		timeZone ??= page.timeZone;
+		forecastHours.push(...(page.forecastHours ?? []));
+		nextPageToken = page.nextPageToken;
+	} while (nextPageToken && forecastHours.length < FORECAST_HOURS);
+
+	return {
+		forecastHours: forecastHours.slice(0, FORECAST_HOURS),
+		timeZone,
+	};
+}
+
+async function fetchGoogleHourlyWeatherPage(
+	apiKey: string,
+	latitude: number,
+	longitude: number,
+	pageToken?: string,
+): Promise<GoogleHourlyResponse> {
 	const url = new URL(GOOGLE_WEATHER_BASE_URL);
-	url.search = new URLSearchParams({
+	const params = new URLSearchParams({
 		key: apiKey,
 		"location.latitude": latitude.toString(),
 		"location.longitude": longitude.toString(),
 		unitsSystem: "IMPERIAL",
-		hours: "24",
+		hours: FORECAST_HOURS.toString(),
 		pageSize: "24",
 		languageCode: "en",
-	}).toString();
+	});
+
+	if (pageToken) {
+		params.set("pageToken", pageToken);
+	}
+
+	url.search = params.toString();
 
 	const response = await fetch(url);
 	if (!response.ok) {

--- a/api/google-weather.ts
+++ b/api/google-weather.ts
@@ -8,6 +8,7 @@ type WeatherOverview = {
 };
 
 type WeatherData = {
+	provider: "google";
 	current: {
 		dt: number;
 		temp: number;
@@ -70,11 +71,6 @@ type OpenMeteoAqiResponse = {
 	};
 };
 
-type CacheEntry = {
-	expiresAt: number;
-	body: WeatherData;
-};
-
 type RateLimitEntry = {
 	windowStart: number;
 	count: number;
@@ -87,22 +83,17 @@ const OPEN_METEO_AQI_URL =
 	"https://air-quality-api.open-meteo.com/v1/air-quality";
 const FORECAST_DAYS = 3;
 const MAX_GOOGLE_FORECAST_HOURS = 72;
-const CACHE_TTL_MS = 5 * 60 * 1000;
 const RATE_LIMIT_WINDOW_MS = 60 * 60 * 1000;
 const RATE_LIMIT_MAX = 30;
 
 const globalRuntime = globalThis as typeof globalThis & {
-	__sunburnGoogleWeatherCache?: Map<string, CacheEntry>;
 	__sunburnGoogleWeatherRateLimit?: Map<string, RateLimitEntry>;
 };
 
-const weatherCache =
-	globalRuntime.__sunburnGoogleWeatherCache ?? new Map<string, CacheEntry>();
 const rateLimit =
 	globalRuntime.__sunburnGoogleWeatherRateLimit ??
 	new Map<string, RateLimitEntry>();
 
-globalRuntime.__sunburnGoogleWeatherCache = weatherCache;
 globalRuntime.__sunburnGoogleWeatherRateLimit = rateLimit;
 
 export default {
@@ -140,34 +131,15 @@ export default {
 			);
 		}
 
-		const roundedLatitude = roundCoordinate(latitude);
-		const roundedLongitude = roundCoordinate(longitude);
-		const cacheKey = [
-			"google-weather-v1",
-			roundedLatitude,
-			roundedLongitude,
-			new Date().toISOString().slice(0, 13),
-		].join(":");
-
-		const cached = weatherCache.get(cacheKey);
-		if (cached && cached.expiresAt > Date.now()) {
-			return weatherResponse(cached.body, "HIT");
-		}
-
 		try {
 			const [googleWeather, metadata, aqi] = await Promise.all([
-				fetchGoogleHourlyWeather(apiKey, roundedLatitude, roundedLongitude),
-				fetchOpenMeteoMetadata(roundedLatitude, roundedLongitude),
-				fetchOpenMeteoAqi(roundedLatitude, roundedLongitude),
+				fetchGoogleHourlyWeather(apiKey, latitude, longitude),
+				fetchOpenMeteoMetadata(latitude, longitude),
+				fetchOpenMeteoAqi(latitude, longitude),
 			]);
 			const weather = normalizeWeatherData(googleWeather, metadata, aqi);
 
-			weatherCache.set(cacheKey, {
-				expiresAt: Date.now() + CACHE_TTL_MS,
-				body: weather,
-			});
-
-			return weatherResponse(weather, "MISS");
+			return weatherResponse(weather);
 		} catch (error) {
 			return jsonResponse(
 				{
@@ -248,10 +220,6 @@ function parseCoordinate(
 	}
 
 	return coordinate;
-}
-
-function roundCoordinate(coordinate: number): number {
-	return Number(coordinate.toFixed(3));
 }
 
 async function fetchGoogleHourlyWeather(
@@ -404,6 +372,7 @@ function normalizeWeatherData(
 	}
 
 	return {
+		provider: "google",
 		current,
 		hourly: filteredHourly,
 		elevation: metadata.elevation ?? 0,
@@ -491,14 +460,10 @@ function toTitleCase(value: string): string {
 	return value.replace(/\b\w/g, (char) => char.toUpperCase());
 }
 
-function weatherResponse(
-	body: WeatherData,
-	cacheStatus: "HIT" | "MISS",
-): Response {
+function weatherResponse(body: WeatherData): Response {
 	return jsonResponse(body, 200, {
 		"Cache-Control": "no-store",
 		"X-Weather-Provider": "google",
-		"X-Cache-Status": cacheStatus,
 	});
 }
 

--- a/api/google-weather.ts
+++ b/api/google-weather.ts
@@ -86,7 +86,7 @@ const OPEN_METEO_FORECAST_URL = "https://api.open-meteo.com/v1/forecast";
 const OPEN_METEO_AQI_URL =
 	"https://air-quality-api.open-meteo.com/v1/air-quality";
 const FORECAST_HOURS = 72;
-const CACHE_TTL_MS = 30 * 60 * 1000;
+const CACHE_TTL_MS = 5 * 60 * 1000;
 const RATE_LIMIT_WINDOW_MS = 60 * 60 * 1000;
 const RATE_LIMIT_MAX = 30;
 
@@ -448,8 +448,7 @@ function weatherResponse(
 	cacheStatus: "HIT" | "MISS",
 ): Response {
 	return jsonResponse(body, 200, {
-		"Cache-Control":
-			"public, max-age=0, s-maxage=1800, stale-while-revalidate=1800",
+		"Cache-Control": "no-store",
 		"X-Weather-Provider": "google",
 		"X-Cache-Status": cacheStatus,
 	});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,7 +10,7 @@ import {
 	DEFAULT_SWEAT_LEVEL,
 } from "./types";
 import { useLocationRefresh } from "./hooks/useLocationRefresh";
-import { fetchWeatherData } from "./services/weather";
+import { fetchWeatherData, getActiveWeatherProvider } from "./services/weather";
 import { getUVIndexColor, getAQIColor } from "./lib/utils";
 
 import { SkinTypeSelector } from "./components/SkinTypeSelector";
@@ -50,6 +50,7 @@ function App() {
 	} = useAppStore();
 
 	const isReadyToCalculate = useIsReadyToCalculate();
+	const isGoogleWeatherMode = getActiveWeatherProvider() === "google";
 
 	// Check if user has pre-loaded preferences (returning user)
 	const hasPreloadedPrefs = !!(skinType && spfLevel);
@@ -126,6 +127,11 @@ function App() {
 					</p>
 					<p className="text-slate-500 text-sm">
 						by <span className="font-medium">SunburnTimer</span>
+						{isGoogleWeatherMode && (
+							<Badge variant="secondary" className="ml-2 align-middle">
+								Google Weather test
+							</Badge>
+						)}
 					</p>
 				</div>
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import {
 import { useLocationRefresh } from "./hooks/useLocationRefresh";
 import {
 	fetchWeatherData,
+	fetchEnsembleWeatherData,
 	getActiveWeatherProvider,
 	isGoogleWeatherTestRoute,
 } from "./services/weather";
@@ -22,6 +23,7 @@ import { SPFSelector } from "./components/SPFSelector";
 import { SweatLevelSelector } from "./components/SweatLevelSelector";
 import { LocationSelector } from "./components/LocationSelector";
 import { ResultsDisplay } from "./components/ResultsDisplay";
+import { EnsembleResultsDisplay } from "./components/EnsembleResultsDisplay";
 import { BurnChart } from "./components/BurnChart";
 import { UVChart } from "./components/UVChart";
 import {
@@ -48,9 +50,12 @@ function App() {
 		weatherProvider,
 		geolocation,
 		calculation,
+		ensembleCalculation,
 		setCalculation,
+		setEnsembleCalculation,
 		setGeolocationStatus,
 		setWeather,
+		setEnsembleWeather,
 		setGeolocationError,
 	} = useAppStore();
 
@@ -60,6 +65,9 @@ function App() {
 			? weatherProvider
 			: getActiveWeatherProvider();
 	const isGoogleWeatherMode = activeWeatherProvider === "google";
+	const isEnsembleMode = activeWeatherProvider === "ensemble";
+	const displayedCalculation =
+		calculation ?? ensembleCalculation?.recommended.result;
 
 	// Check if user has pre-loaded preferences (returning user)
 	const hasPreloadedPrefs = !!(skinType && spfLevel);
@@ -71,7 +79,7 @@ function App() {
 	useEffect(() => {
 		if (
 			!isReadyToCalculate ||
-			!geolocation.weather ||
+			(!geolocation.weather && !geolocation.ensembleWeather) ||
 			!geolocation.placeName ||
 			!skinType ||
 			!spfLevel
@@ -79,25 +87,54 @@ function App() {
 			return;
 		}
 
-		const input = {
-			weather: geolocation.weather,
+		const currentTime = new Date();
+		const commonInput = {
 			placeName: geolocation.placeName,
-			currentTime: new Date(),
+			currentTime,
 			skinType,
 			spfLevel,
 			sweatLevel: sweatLevel ?? DEFAULT_SWEAT_LEVEL,
 		};
 
-		const result = findOptimalTimeSlicing(input);
-		setCalculation(result);
+		if (activeWeatherProvider === "ensemble" && geolocation.ensembleWeather) {
+			const providers = geolocation.ensembleWeather.map((weather) => ({
+				provider: weather.provider,
+				result: findOptimalTimeSlicing({
+					...commonInput,
+					weather,
+				}),
+			}));
+			const ranked = [...providers].sort((a, b) => {
+				if (!a.result.burnTime && !b.result.burnTime) return 0;
+				if (!a.result.burnTime) return 1;
+				if (!b.result.burnTime) return -1;
+				return a.result.burnTime.getTime() - b.result.burnTime.getTime();
+			});
+			const recommended = ranked[0];
+			if (!recommended) return;
+			setEnsembleCalculation({
+				providers: ranked,
+				recommended,
+				optimistic: ranked[ranked.length - 1],
+			});
+		} else if (geolocation.weather) {
+			const result = findOptimalTimeSlicing({
+				...commonInput,
+				weather: geolocation.weather,
+			});
+			setCalculation(result);
+		}
 	}, [
 		isReadyToCalculate,
+		activeWeatherProvider,
 		skinType,
 		spfLevel,
 		sweatLevel,
 		geolocation.weather,
+		geolocation.ensembleWeather,
 		geolocation.placeName,
 		setCalculation,
+		setEnsembleCalculation,
 	]);
 
 	const handleRefresh = async () => {
@@ -106,6 +143,17 @@ function App() {
 		try {
 			haptic();
 			setGeolocationStatus("fetching_weather");
+			if (activeWeatherProvider === "ensemble") {
+				const weather = await fetchEnsembleWeatherData(
+					geolocation.position,
+					geolocation.placeName,
+					geolocation.countryCode,
+				);
+				setEnsembleWeather(weather);
+				haptic.confirm();
+				return;
+			}
+
 			const weather = await fetchWeatherData(
 				geolocation.position,
 				activeWeatherProvider,
@@ -139,9 +187,9 @@ function App() {
 					</p>
 					<p className="text-slate-500 text-sm">
 						by <span className="font-medium">SunburnTimer</span>
-						{isGoogleWeatherMode && (
+						{(isGoogleWeatherMode || isEnsembleMode) && (
 							<Badge variant="secondary" className="ml-2 align-middle">
-								Google Weather test
+								{isEnsembleMode ? "Provider range test" : "Google Weather test"}
 							</Badge>
 						)}
 					</p>
@@ -283,7 +331,7 @@ function App() {
 				</Accordion>
 
 				{/* Results */}
-				{calculation && (
+				{displayedCalculation && (
 					<div className="mt-8 space-y-6">
 						<div className="flex items-center justify-between">
 							<h2 className="text-2xl font-bold text-slate-800">
@@ -308,22 +356,28 @@ function App() {
 							</div>
 						</div>
 
-						<ResultsDisplay
-							result={calculation}
-							timezone={geolocation.weather?.timezone}
-						/>
+						{ensembleCalculation ? (
+							<EnsembleResultsDisplay ensemble={ensembleCalculation} />
+						) : (
+							calculation && (
+								<ResultsDisplay
+									result={calculation}
+									timezone={geolocation.weather?.timezone}
+								/>
+							)
+						)}
 						<div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
 							<BurnChart
-								result={calculation}
+								result={displayedCalculation}
 								timezone={geolocation.weather?.timezone}
 							/>
 							<UVChart
-								result={calculation}
+								result={displayedCalculation}
 								timezone={geolocation.weather?.timezone}
 							/>
 						</div>
 						<SunPositionCard />
-						<SunTimer result={calculation} />
+						<SunTimer result={displayedCalculation} />
 					</div>
 				)}
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,7 +10,11 @@ import {
 	DEFAULT_SWEAT_LEVEL,
 } from "./types";
 import { useLocationRefresh } from "./hooks/useLocationRefresh";
-import { fetchWeatherData, getActiveWeatherProvider } from "./services/weather";
+import {
+	fetchWeatherData,
+	getActiveWeatherProvider,
+	isGoogleWeatherTestRoute,
+} from "./services/weather";
 import { getUVIndexColor, getAQIColor } from "./lib/utils";
 
 import { SkinTypeSelector } from "./components/SkinTypeSelector";
@@ -41,6 +45,7 @@ function App() {
 		skinType,
 		spfLevel,
 		sweatLevel,
+		weatherProvider,
 		geolocation,
 		calculation,
 		setCalculation,
@@ -50,7 +55,11 @@ function App() {
 	} = useAppStore();
 
 	const isReadyToCalculate = useIsReadyToCalculate();
-	const isGoogleWeatherMode = getActiveWeatherProvider() === "google";
+	const activeWeatherProvider =
+		isGoogleWeatherTestRoute() && weatherProvider
+			? weatherProvider
+			: getActiveWeatherProvider();
+	const isGoogleWeatherMode = activeWeatherProvider === "google";
 
 	// Check if user has pre-loaded preferences (returning user)
 	const hasPreloadedPrefs = !!(skinType && spfLevel);
@@ -97,7 +106,10 @@ function App() {
 		try {
 			haptic();
 			setGeolocationStatus("fetching_weather");
-			const weather = await fetchWeatherData(geolocation.position);
+			const weather = await fetchWeatherData(
+				geolocation.position,
+				activeWeatherProvider,
+			);
 			haptic.confirm();
 			setWeather(weather);
 		} catch (error) {

--- a/src/calculations.test.ts
+++ b/src/calculations.test.ts
@@ -11,6 +11,7 @@ function createMockWeatherData(
 	const timestamp = baseTime || Math.floor(Date.now() / 1000);
 
 	return {
+		provider: "open-meteo",
 		current: {
 			dt: timestamp,
 			temp: 75,

--- a/src/calculations.ts
+++ b/src/calculations.ts
@@ -50,9 +50,9 @@ function spfAtTime(
 	return Math.max(1.0, remainingSpfValue);
 }
 
-// **Low-UV ramp: smoothstep between configured [low, high]
-// At very low UV (e.g., <1), damage is negligible. This smoothly ramps up the weighting from 0 to full effect,
-// avoiding overestimation in dawn/dusk or cloudy conditions. Smoothstep is a curved transition for natural feel.**
+// Open-Meteo can report measurable UV around dawn/dusk that made estimates feel
+// too conservative. Google UV is already condition-adjusted enough for this pass,
+// so Google weather bypasses this weighting.
 function lowUvWeight(uvi: number): number {
 	const { LOW_UV_SMOOTHSTEP_ENABLED, LOW_UV_RAMP_LOW, LOW_UV_RAMP_HIGH } =
 		CALCULATION_CONSTANTS;
@@ -64,7 +64,7 @@ function lowUvWeight(uvi: number): number {
 		0,
 		Math.min(1, (uvi - lowThreshold) / (highThreshold - lowThreshold)),
 	);
-	return normalizedUvi * normalizedUvi * (3 - 2 * normalizedUvi); // smoothstep formula: cubic curve for smooth start/end.
+	return normalizedUvi * normalizedUvi * (3 - 2 * normalizedUvi);
 }
 
 type SliceWindow = {
@@ -181,6 +181,7 @@ function calculateBurnTimeWithSlices(
 		SPF_CONFIG[SPFLevel.NONE].coefficient;
 	const startTimestampMs = input.currentTime.getTime();
 	const threshold = CALCULATION_CONSTANTS.DAMAGE_THRESHOLD;
+	const shouldApplyLowUvWeight = input.weather.provider !== "google";
 	const points: CalculationPoint[] = [];
 	let totalDamage = 0;
 	let pointCount = 0;
@@ -222,12 +223,16 @@ function calculateBurnTimeWithSlices(
 			hoursFromStartAtEnd,
 		);
 		// Trapezoid on effective irradiance (UVI/SPF)
-		// **Effective irradiance: UV strength divided by SPF, weighted for low UV. Average start/end for smooth integration.**
+		// **Effective irradiance: UV strength divided by SPF. Average start/end for smooth integration.**
+		const lowUvWeightAtStart = shouldApplyLowUvWeight
+			? lowUvWeight(uviAtEffectiveStart)
+			: 1;
+		const lowUvWeightAtEnd = shouldApplyLowUvWeight ? lowUvWeight(uviAtEnd) : 1;
 		const effectiveIrradianceStart =
 			(uviAtEffectiveStart / Math.max(1, spfAtEffectiveStart)) *
-			lowUvWeight(uviAtEffectiveStart);
+			lowUvWeightAtStart;
 		const effectiveIrradianceEnd =
-			(uviAtEnd / Math.max(1, spfAtEnd)) * lowUvWeight(uviAtEnd);
+			(uviAtEnd / Math.max(1, spfAtEnd)) * lowUvWeightAtEnd;
 		const averageEffectiveIrradiance =
 			0.5 * (effectiveIrradianceStart + effectiveIrradianceEnd);
 		// Damage% added in this (possibly partial) window

--- a/src/components/EnsembleResultsDisplay.tsx
+++ b/src/components/EnsembleResultsDisplay.tsx
@@ -1,0 +1,121 @@
+import { format } from "date-fns";
+import { CheckCircle, Sun } from "lucide-react";
+import type {
+	ActualWeatherProvider,
+	EnsembleCalculationResult,
+	ProviderCalculationResult,
+} from "../types";
+import { getWeatherProviderLabel } from "../services/weather";
+import { formatDuration } from "../lib/utils";
+import { Card, CardContent } from "./ui/card";
+import { Badge } from "./ui/badge";
+
+interface EnsembleResultsDisplayProps {
+	ensemble: EnsembleCalculationResult;
+}
+
+function getSafeTime(result: ProviderCalculationResult): string {
+	const { startTime, burnTime } = result.result;
+	if (!startTime || !burnTime) {
+		return "Unlikely";
+	}
+
+	if (burnTime.getDate() !== startTime.getDate()) {
+		return "Unlikely";
+	}
+
+	return formatDuration(burnTime.getTime() - startTime.getTime());
+}
+
+function getRangeLabel(ensemble: EnsembleCalculationResult): string {
+	const burnTimes = ensemble.providers
+		.map(({ result }) => result.burnTime)
+		.filter((burnTime) => burnTime !== undefined);
+
+	if (burnTimes.length === 0) {
+		return "Sunburn unlikely";
+	}
+
+	const startTime = ensemble.recommended.result.startTime;
+	if (!startTime) {
+		return "Sunburn unlikely";
+	}
+
+	const durations = burnTimes.map((burnTime) =>
+		formatDuration(burnTime.getTime() - startTime.getTime()),
+	);
+
+	const first = durations[0];
+	const last = durations[durations.length - 1];
+	return first === last ? first : `${first} - ${last}`;
+}
+
+function getProviderTone(provider: ActualWeatherProvider): string {
+	switch (provider) {
+		case "google":
+			return "bg-blue-50 text-blue-900 border-blue-200";
+		case "epa":
+			return "bg-green-50 text-green-900 border-green-200";
+		case "open-meteo":
+			return "bg-orange-50 text-orange-900 border-orange-200";
+	}
+}
+
+export function EnsembleResultsDisplay({
+	ensemble,
+}: EnsembleResultsDisplayProps) {
+	const rangeLabel = getRangeLabel(ensemble);
+	const hasBurnTime = ensemble.providers.some(({ result }) => result.burnTime);
+	const recommendedBurnTime = ensemble.recommended.result.burnTime;
+
+	return (
+		<Card>
+			<CardContent className="pt-6">
+				<div className="space-y-5">
+					<div className="flex flex-col items-center gap-3 text-center">
+						{hasBurnTime ? (
+							<Sun className="h-8 w-8 text-orange-500" />
+						) : (
+							<CheckCircle className="h-8 w-8 text-green-600" />
+						)}
+						<div>
+							<p className="text-2xl font-bold tabular-nums text-slate-800">
+								{hasBurnTime ? `Safe for ${rangeLabel}` : rangeLabel}
+							</p>
+							{recommendedBurnTime && (
+								<p className="text-slate-600 tabular-nums">
+									Use the conservative estimate:{" "}
+									{format(recommendedBurnTime, "h:mm a")}
+								</p>
+							)}
+						</div>
+					</div>
+
+					<div className="grid gap-2">
+						{ensemble.providers.map((providerResult) => (
+							<div
+								key={providerResult.provider}
+								className="flex items-center justify-between rounded-md border border-stone-200 bg-white px-3 py-2"
+							>
+								<Badge
+									variant="outline"
+									className={getProviderTone(providerResult.provider)}
+								>
+									{getWeatherProviderLabel(providerResult.provider)}
+								</Badge>
+								<span className="text-sm font-medium tabular-nums text-slate-700">
+									{getSafeTime(providerResult)}
+								</span>
+							</div>
+						))}
+					</div>
+
+					<p className="text-center text-xs text-slate-500">
+						Range mode runs each provider independently and uses the earliest
+						burn time as the conservative estimate.
+					</p>
+				</div>
+			</CardContent>
+		</Card>
+	);
+}

--- a/src/components/LocationSelector.tsx
+++ b/src/components/LocationSelector.tsx
@@ -1,3 +1,4 @@
+import { useId } from "react";
 import {
 	MapPin,
 	LoaderIcon,
@@ -13,21 +14,48 @@ import {
 	reverseGeocode,
 	formatElevation,
 } from "../services/geolocation";
-import { fetchWeatherData } from "../services/weather";
+import {
+	fetchWeatherData,
+	getActiveWeatherProvider,
+	isGoogleWeatherTestRoute,
+} from "../services/weather";
 import { LocationSearch } from "./LocationSearch";
 import type { GeocodingResult } from "../services/geocoding";
+import type { WeatherProvider } from "../types";
 import { Card, CardContent } from "./ui/card";
 import { Button } from "./ui/button";
 import { Alert, AlertDescription } from "./ui/alert";
+import { Label } from "./ui/label";
+import { RadioGroup, RadioGroupItem } from "./ui/radio-group";
 
 export function LocationSelector() {
+	const openMeteoProviderId = useId();
+	const googleProviderId = useId();
 	const {
 		geolocation,
+		weatherProvider,
 		setGeolocationStatus,
 		setPosition,
 		setWeather,
 		setGeolocationError,
+		setWeatherProvider,
 	} = useAppStore();
+	const canChooseWeatherProvider = isGoogleWeatherTestRoute();
+	const activeWeatherProvider =
+		canChooseWeatherProvider && weatherProvider
+			? weatherProvider
+			: getActiveWeatherProvider();
+
+	const refreshWeatherForProvider = async (
+		provider: WeatherProvider,
+		position = geolocation.position,
+	) => {
+		if (!position) return;
+
+		setGeolocationStatus("fetching_weather");
+		const weather = await fetchWeatherData(position, provider);
+		setWeather(weather);
+	};
 
 	const handleSearchSelect = async (result: GeocodingResult) => {
 		try {
@@ -42,7 +70,7 @@ export function LocationSelector() {
 			setPosition(position, placeName, result.countryCode);
 
 			setGeolocationStatus("fetching_weather");
-			const weather = await fetchWeatherData(position);
+			const weather = await fetchWeatherData(position, activeWeatherProvider);
 			haptic.confirm();
 			setWeather(weather);
 		} catch (error) {
@@ -63,13 +91,27 @@ export function LocationSelector() {
 			setPosition(position, placeName, countryCode);
 
 			setGeolocationStatus("fetching_weather");
-			const weather = await fetchWeatherData(position);
+			const weather = await fetchWeatherData(position, activeWeatherProvider);
 			haptic.confirm();
 			setWeather(weather);
 		} catch (error) {
 			haptic.error();
 			setGeolocationError(
 				error instanceof Error ? error.message : "Failed to get location",
+			);
+		}
+	};
+
+	const handleWeatherProviderChange = async (provider: WeatherProvider) => {
+		try {
+			haptic();
+			setWeatherProvider(provider);
+			await refreshWeatherForProvider(provider);
+			haptic.confirm();
+		} catch (error) {
+			haptic.error();
+			setGeolocationError(
+				error instanceof Error ? error.message : "Failed to fetch weather",
 			);
 		}
 	};
@@ -267,6 +309,37 @@ export function LocationSelector() {
 
 	return (
 		<div className="space-y-6">
+			{canChooseWeatherProvider && (
+				<div className="space-y-3">
+					<Label className="text-sm font-medium text-slate-700">
+						Weather provider
+					</Label>
+					<RadioGroup
+						value={activeWeatherProvider}
+						onValueChange={(value) =>
+							handleWeatherProviderChange(value as WeatherProvider)
+						}
+						disabled={isLoading}
+						className="grid grid-cols-2 gap-2"
+					>
+						<Label
+							htmlFor={openMeteoProviderId}
+							className="flex cursor-pointer items-center gap-3 rounded-md border border-stone-200 bg-white px-3 py-2 text-sm text-slate-700 transition-colors has-[[data-state=checked]]:border-amber-500 has-[[data-state=checked]]:bg-amber-50 has-[[data-state=checked]]:text-amber-950"
+						>
+							<RadioGroupItem id={openMeteoProviderId} value="open-meteo" />
+							Open-Meteo
+						</Label>
+						<Label
+							htmlFor={googleProviderId}
+							className="flex cursor-pointer items-center gap-3 rounded-md border border-stone-200 bg-white px-3 py-2 text-sm text-slate-700 transition-colors has-[[data-state=checked]]:border-amber-500 has-[[data-state=checked]]:bg-amber-50 has-[[data-state=checked]]:text-amber-950"
+						>
+							<RadioGroupItem id={googleProviderId} value="google" />
+							Google
+						</Label>
+					</RadioGroup>
+				</div>
+			)}
+
 			<div className="grid grid-cols-1 gap-4">
 				<Button
 					variant="outline"

--- a/src/components/LocationSelector.tsx
+++ b/src/components/LocationSelector.tsx
@@ -15,6 +15,7 @@ import {
 	formatElevation,
 } from "../services/geolocation";
 import {
+	fetchEnsembleWeatherData,
 	fetchWeatherData,
 	getActiveWeatherProvider,
 	isGoogleWeatherTestRoute,
@@ -31,12 +32,14 @@ import { RadioGroup, RadioGroupItem } from "./ui/radio-group";
 export function LocationSelector() {
 	const openMeteoProviderId = useId();
 	const googleProviderId = useId();
+	const ensembleProviderId = useId();
 	const {
 		geolocation,
 		weatherProvider,
 		setGeolocationStatus,
 		setPosition,
 		setWeather,
+		setEnsembleWeather,
 		setGeolocationError,
 		setWeatherProvider,
 	} = useAppStore();
@@ -53,6 +56,15 @@ export function LocationSelector() {
 		if (!position) return;
 
 		setGeolocationStatus("fetching_weather");
+		if (provider === "ensemble") {
+			const weather = await fetchEnsembleWeatherData(
+				position,
+				geolocation.placeName,
+				geolocation.countryCode,
+			);
+			setEnsembleWeather(weather);
+			return;
+		}
 		const weather = await fetchWeatherData(position, provider);
 		setWeather(weather);
 	};
@@ -70,6 +82,16 @@ export function LocationSelector() {
 			setPosition(position, placeName, result.countryCode);
 
 			setGeolocationStatus("fetching_weather");
+			if (activeWeatherProvider === "ensemble") {
+				const weather = await fetchEnsembleWeatherData(
+					position,
+					placeName,
+					result.countryCode,
+				);
+				haptic.confirm();
+				setEnsembleWeather(weather);
+				return;
+			}
 			const weather = await fetchWeatherData(position, activeWeatherProvider);
 			haptic.confirm();
 			setWeather(weather);
@@ -91,6 +113,16 @@ export function LocationSelector() {
 			setPosition(position, placeName, countryCode);
 
 			setGeolocationStatus("fetching_weather");
+			if (activeWeatherProvider === "ensemble") {
+				const weather = await fetchEnsembleWeatherData(
+					position,
+					placeName,
+					countryCode,
+				);
+				haptic.confirm();
+				setEnsembleWeather(weather);
+				return;
+			}
 			const weather = await fetchWeatherData(position, activeWeatherProvider);
 			haptic.confirm();
 			setWeather(weather);
@@ -320,7 +352,7 @@ export function LocationSelector() {
 							handleWeatherProviderChange(value as WeatherProvider)
 						}
 						disabled={isLoading}
-						className="grid grid-cols-2 gap-2"
+						className="grid grid-cols-3 gap-2"
 					>
 						<Label
 							htmlFor={openMeteoProviderId}
@@ -335,6 +367,13 @@ export function LocationSelector() {
 						>
 							<RadioGroupItem id={googleProviderId} value="google" />
 							Google
+						</Label>
+						<Label
+							htmlFor={ensembleProviderId}
+							className="flex cursor-pointer items-center gap-3 rounded-md border border-stone-200 bg-white px-3 py-2 text-sm text-slate-700 transition-colors has-[[data-state=checked]]:border-amber-500 has-[[data-state=checked]]:bg-amber-50 has-[[data-state=checked]]:text-amber-950"
+						>
+							<RadioGroupItem id={ensembleProviderId} value="ensemble" />
+							Range
 						</Label>
 					</RadioGroup>
 				</div>

--- a/src/components/MathExplanation.tsx
+++ b/src/components/MathExplanation.tsx
@@ -165,22 +165,24 @@ export function MathExplanation() {
 								<li>
 									<a
 										href={
-											weatherProvider === "google"
-												? "https://developers.google.com/maps/documentation/weather"
-												: "https://open-meteo.com/"
+											weatherProvider === "open-meteo"
+												? "https://open-meteo.com/"
+												: "https://developers.google.com/maps/documentation/weather"
 										}
 										target="_blank"
 										rel="noopener noreferrer"
 										className="text-slate-600 hover:text-amber-600 hover:underline transition-colors"
 									>
-										{weatherProvider === "google"
-											? "Google Weather API"
-											: "Open-Meteo"}
+										{weatherProvider === "open-meteo"
+											? "Open-Meteo"
+											: "Google Weather API"}
 									</a>
 									<span className="text-slate-400">
-										{weatherProvider === "google"
-											? " (UV forecast test data)"
-											: " (weather data)"}
+										{weatherProvider === "ensemble"
+											? " (provider range test data)"
+											: weatherProvider === "google"
+												? " (UV forecast test data)"
+												: " (weather data)"}
 									</span>
 								</li>
 								{weatherProvider === "google" && (
@@ -196,6 +198,22 @@ export function MathExplanation() {
 										<span className="text-slate-400">
 											{" "}
 											(elevation, sun timing, and AQI metadata)
+										</span>
+									</li>
+								)}
+								{weatherProvider === "ensemble" && (
+									<li>
+										<a
+											href="https://www.epa.gov/enviro/web-services"
+											target="_blank"
+											rel="noopener noreferrer"
+											className="text-slate-600 hover:text-amber-600 hover:underline transition-colors"
+										>
+											EPA UV Index
+										</a>
+										<span className="text-slate-400">
+											{" "}
+											(US hourly UV forecast when available)
 										</span>
 									</li>
 								)}

--- a/src/components/MathExplanation.tsx
+++ b/src/components/MathExplanation.tsx
@@ -5,10 +5,20 @@ import {
 	AccordionTrigger,
 } from "@/components/ui/accordion";
 import { Calculator, Sun, Shield, User } from "lucide-react";
-import { getActiveWeatherProvider } from "@/services/weather";
+import { useAppStore } from "@/store";
+import {
+	getActiveWeatherProvider,
+	isGoogleWeatherTestRoute,
+} from "@/services/weather";
 
 export function MathExplanation() {
-	const weatherProvider = getActiveWeatherProvider();
+	const weatherProviderPreference = useAppStore(
+		(state) => state.weatherProvider,
+	);
+	const weatherProvider =
+		isGoogleWeatherTestRoute() && weatherProviderPreference
+			? weatherProviderPreference
+			: getActiveWeatherProvider();
 
 	return (
 		<Accordion type="single" collapsible className="w-full">

--- a/src/components/MathExplanation.tsx
+++ b/src/components/MathExplanation.tsx
@@ -5,8 +5,11 @@ import {
 	AccordionTrigger,
 } from "@/components/ui/accordion";
 import { Calculator, Sun, Shield, User } from "lucide-react";
+import { getActiveWeatherProvider } from "@/services/weather";
 
 export function MathExplanation() {
+	const weatherProvider = getActiveWeatherProvider();
+
 	return (
 		<Accordion type="single" collapsible className="w-full">
 			<AccordionItem
@@ -151,15 +154,41 @@ export function MathExplanation() {
 								</li>
 								<li>
 									<a
-										href="https://open-meteo.com/"
+										href={
+											weatherProvider === "google"
+												? "https://developers.google.com/maps/documentation/weather"
+												: "https://open-meteo.com/"
+										}
 										target="_blank"
 										rel="noopener noreferrer"
 										className="text-slate-600 hover:text-amber-600 hover:underline transition-colors"
 									>
-										Open-Meteo
+										{weatherProvider === "google"
+											? "Google Weather API"
+											: "Open-Meteo"}
 									</a>
-									<span className="text-slate-400"> (weather data)</span>
+									<span className="text-slate-400">
+										{weatherProvider === "google"
+											? " (UV forecast test data)"
+											: " (weather data)"}
+									</span>
 								</li>
+								{weatherProvider === "google" && (
+									<li>
+										<a
+											href="https://open-meteo.com/"
+											target="_blank"
+											rel="noopener noreferrer"
+											className="text-slate-600 hover:text-amber-600 hover:underline transition-colors"
+										>
+											Open-Meteo
+										</a>
+										<span className="text-slate-400">
+											{" "}
+											(elevation, sun timing, and AQI metadata)
+										</span>
+									</li>
+								)}
 							</ul>
 						</div>
 					</div>

--- a/src/hooks/useLocationRefresh.ts
+++ b/src/hooks/useLocationRefresh.ts
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
 import { useAppStore } from "../store";
 import {
+	fetchEnsembleWeatherData,
 	fetchWeatherData,
 	getActiveWeatherProvider,
 	isGoogleWeatherTestRoute,
@@ -12,6 +13,7 @@ export function useLocationRefresh() {
 		weatherProvider,
 		setGeolocationStatus,
 		setWeather,
+		setEnsembleWeather,
 		setGeolocationError,
 	} = useAppStore();
 	const activeWeatherProvider =
@@ -30,6 +32,15 @@ export function useLocationRefresh() {
 			const refreshWeather = async () => {
 				try {
 					setGeolocationStatus("fetching_weather");
+					if (activeWeatherProvider === "ensemble") {
+						const weather = await fetchEnsembleWeatherData(
+							position,
+							geolocation.placeName,
+							geolocation.countryCode,
+						);
+						setEnsembleWeather(weather);
+						return;
+					}
 					const weather = await fetchWeatherData(
 						position,
 						activeWeatherProvider,
@@ -49,10 +60,13 @@ export function useLocationRefresh() {
 	}, [
 		geolocation.status,
 		geolocation.position,
+		geolocation.placeName,
+		geolocation.countryCode,
 		geolocation.weather,
 		activeWeatherProvider,
 		setGeolocationStatus,
 		setWeather,
+		setEnsembleWeather,
 		setGeolocationError,
 	]);
 }

--- a/src/hooks/useLocationRefresh.ts
+++ b/src/hooks/useLocationRefresh.ts
@@ -1,10 +1,23 @@
 import { useEffect } from "react";
 import { useAppStore } from "../store";
-import { fetchWeatherData } from "../services/weather";
+import {
+	fetchWeatherData,
+	getActiveWeatherProvider,
+	isGoogleWeatherTestRoute,
+} from "../services/weather";
 
 export function useLocationRefresh() {
-	const { geolocation, setGeolocationStatus, setWeather, setGeolocationError } =
-		useAppStore();
+	const {
+		geolocation,
+		weatherProvider,
+		setGeolocationStatus,
+		setWeather,
+		setGeolocationError,
+	} = useAppStore();
+	const activeWeatherProvider =
+		isGoogleWeatherTestRoute() && weatherProvider
+			? weatherProvider
+			: getActiveWeatherProvider();
 
 	useEffect(() => {
 		// If we have a saved location but no weather data, refresh the weather
@@ -17,7 +30,10 @@ export function useLocationRefresh() {
 			const refreshWeather = async () => {
 				try {
 					setGeolocationStatus("fetching_weather");
-					const weather = await fetchWeatherData(position);
+					const weather = await fetchWeatherData(
+						position,
+						activeWeatherProvider,
+					);
 					setWeather(weather);
 				} catch (error) {
 					setGeolocationError(
@@ -34,6 +50,7 @@ export function useLocationRefresh() {
 		geolocation.status,
 		geolocation.position,
 		geolocation.weather,
+		activeWeatherProvider,
 		setGeolocationStatus,
 		setWeather,
 		setGeolocationError,

--- a/src/services/weather.ts
+++ b/src/services/weather.ts
@@ -62,8 +62,8 @@ async function fetchGoogleWeatherData(
 	position: Position,
 ): Promise<WeatherData> {
 	const params = new URLSearchParams({
-		latitude: position.latitude.toFixed(4),
-		longitude: position.longitude.toFixed(4),
+		latitude: position.latitude.toString(),
+		longitude: position.longitude.toString(),
 	});
 
 	const response = await fetch(`/api/google-weather?${params.toString()}`, {
@@ -197,6 +197,7 @@ export async function fetchOpenMeteoWeatherData(
 	}
 
 	return {
+		provider: "open-meteo",
 		current,
 		hourly,
 		elevation: data.elevation,

--- a/src/services/weather.ts
+++ b/src/services/weather.ts
@@ -3,6 +3,8 @@ import type { Position, WeatherData, AQIData } from "../types";
 import { WMO_DESCRIPTIONS } from "../constants/wmo-descriptions";
 import { fetchAQIData } from "./aqi";
 
+export type WeatherProvider = "open-meteo" | "google";
+
 interface OpenMeteoResponse {
 	elevation: number;
 	timezone: string;
@@ -35,7 +37,71 @@ function parseLocationTime(timeStr: string, timezone: string): number {
 	return new TZDate(y, m - 1, d, h, min, 0, timezone).getTime();
 }
 
+export function getActiveWeatherProvider(): WeatherProvider {
+	if (typeof window === "undefined") {
+		return "open-meteo";
+	}
+
+	return window.location.pathname.replace(/\/+$/, "") === "/google"
+		? "google"
+		: "open-meteo";
+}
+
 export async function fetchWeatherData(
+	position: Position,
+): Promise<WeatherData> {
+	if (getActiveWeatherProvider() === "google") {
+		return fetchGoogleWeatherData(position);
+	}
+
+	return fetchOpenMeteoWeatherData(position);
+}
+
+async function fetchGoogleWeatherData(
+	position: Position,
+): Promise<WeatherData> {
+	const params = new URLSearchParams({
+		latitude: position.latitude.toFixed(4),
+		longitude: position.longitude.toFixed(4),
+	});
+
+	const response = await fetch(`/api/google-weather?${params.toString()}`, {
+		headers: {
+			Accept: "application/json",
+		},
+	});
+
+	if (!response.ok) {
+		const message = await readErrorMessage(response);
+		throw new Error(message || `Google Weather API error: ${response.status}`);
+	}
+
+	const contentType = response.headers.get("content-type");
+	if (!contentType?.includes("application/json")) {
+		throw new Error(
+			"Google weather endpoint did not return JSON. Use a Vercel preview deployment or run the app with Vercel dev.",
+		);
+	}
+
+	return response.json();
+}
+
+async function readErrorMessage(
+	response: Response,
+): Promise<string | undefined> {
+	const contentType = response.headers.get("content-type");
+
+	if (contentType?.includes("application/json")) {
+		const body = (await response.json().catch(() => undefined)) as
+			| { error?: string }
+			| undefined;
+		return body?.error;
+	}
+
+	return response.text().catch(() => undefined);
+}
+
+export async function fetchOpenMeteoWeatherData(
 	position: Position,
 ): Promise<WeatherData> {
 	const lat = position.latitude.toFixed(4);

--- a/src/services/weather.ts
+++ b/src/services/weather.ts
@@ -1,5 +1,11 @@
 import { TZDate } from "@date-fns/tz";
-import type { Position, WeatherData, AQIData, WeatherProvider } from "../types";
+import type {
+	ActualWeatherProvider,
+	Position,
+	WeatherData,
+	AQIData,
+	WeatherProvider,
+} from "../types";
 import { WMO_DESCRIPTIONS } from "../constants/wmo-descriptions";
 import { fetchAQIData } from "./aqi";
 
@@ -23,6 +29,64 @@ interface OpenMeteoResponse {
 		sunset: string[];
 	};
 }
+
+interface EPAHourlyUVResponse {
+	DATE_TIME?: string;
+	UV_VALUE?: number | string;
+}
+
+const US_STATE_ABBREVIATIONS: Record<string, string> = {
+	alabama: "AL",
+	alaska: "AK",
+	arizona: "AZ",
+	arkansas: "AR",
+	california: "CA",
+	colorado: "CO",
+	connecticut: "CT",
+	delaware: "DE",
+	florida: "FL",
+	georgia: "GA",
+	hawaii: "HI",
+	idaho: "ID",
+	illinois: "IL",
+	indiana: "IN",
+	iowa: "IA",
+	kansas: "KS",
+	kentucky: "KY",
+	louisiana: "LA",
+	maine: "ME",
+	maryland: "MD",
+	massachusetts: "MA",
+	michigan: "MI",
+	minnesota: "MN",
+	mississippi: "MS",
+	missouri: "MO",
+	montana: "MT",
+	nebraska: "NE",
+	nevada: "NV",
+	"new hampshire": "NH",
+	"new jersey": "NJ",
+	"new mexico": "NM",
+	"new york": "NY",
+	"north carolina": "NC",
+	"north dakota": "ND",
+	ohio: "OH",
+	oklahoma: "OK",
+	oregon: "OR",
+	pennsylvania: "PA",
+	"rhode island": "RI",
+	"south carolina": "SC",
+	"south dakota": "SD",
+	tennessee: "TN",
+	texas: "TX",
+	utah: "UT",
+	vermont: "VT",
+	virginia: "VA",
+	washington: "WA",
+	"west virginia": "WV",
+	wisconsin: "WI",
+	wyoming: "WY",
+};
 
 /**
  * Parse a naive datetime string from Open-Meteo (e.g. "2026-02-22T14:00")
@@ -49,13 +113,32 @@ export function isGoogleWeatherTestRoute(): boolean {
 
 export async function fetchWeatherData(
 	position: Position,
-	provider: WeatherProvider = getActiveWeatherProvider(),
+	provider: ActualWeatherProvider = getActiveWeatherProvider() as ActualWeatherProvider,
 ): Promise<WeatherData> {
 	if (provider === "google") {
 		return fetchGoogleWeatherData(position);
 	}
 
 	return fetchOpenMeteoWeatherData(position);
+}
+
+export async function fetchEnsembleWeatherData(
+	position: Position,
+	placeName?: string,
+	countryCode?: string,
+): Promise<WeatherData[]> {
+	const [openMeteo, google] = await Promise.all([
+		fetchOpenMeteoWeatherData(position),
+		fetchGoogleWeatherData(position),
+	]);
+	const providers = [openMeteo, google];
+	const epa = await fetchEPAWeatherData(openMeteo, placeName, countryCode);
+
+	if (epa) {
+		providers.push(epa);
+	}
+
+	return providers;
 }
 
 async function fetchGoogleWeatherData(
@@ -213,4 +296,143 @@ export async function fetchOpenMeteoWeatherData(
 		).toISOString(),
 		timezone: locationTimezone,
 	};
+}
+
+async function fetchEPAWeatherData(
+	baseWeather: WeatherData,
+	placeName?: string,
+	countryCode?: string,
+): Promise<WeatherData | undefined> {
+	const location = parseUSCityState(placeName, countryCode);
+	if (!location) {
+		return undefined;
+	}
+
+	const url = new URL(
+		`https://data.epa.gov/dmapservice/getEnvirofactsUVHOURLY/CITY/${encodeURIComponent(
+			location.city,
+		)}/STATE/${location.state}/JSON`,
+	);
+	const response = await fetch(url);
+
+	if (!response.ok) {
+		return undefined;
+	}
+
+	const data = (await response.json()) as EPAHourlyUVResponse[];
+	const uvByTime = new Map<number, number>();
+
+	for (const row of data) {
+		const uvValue = Number(row.UV_VALUE);
+		if (!row.DATE_TIME || !Number.isFinite(uvValue)) {
+			continue;
+		}
+
+		const timestamp = parseEPALocationTime(row.DATE_TIME, baseWeather.timezone);
+		uvByTime.set(Math.floor(timestamp / 1000), uvValue);
+	}
+
+	if (uvByTime.size === 0) {
+		return undefined;
+	}
+
+	const hourly = baseWeather.hourly.map((hour) => ({
+		...hour,
+		uvi: uvByTime.get(hour.dt) ?? hour.uvi,
+		weather: [
+			{
+				id: 800,
+				main: "EPA UV",
+				description: "EPA hourly UV forecast",
+				icon: "",
+			},
+		],
+	}));
+
+	return {
+		...baseWeather,
+		provider: "epa",
+		current: {
+			...baseWeather.current,
+			uvi: uvByTime.get(baseWeather.current.dt) ?? baseWeather.current.uvi,
+			weather: [
+				{
+					id: 800,
+					main: "EPA UV",
+					description: "EPA hourly UV forecast",
+					icon: "",
+				},
+			],
+		},
+		hourly,
+	};
+}
+
+function parseUSCityState(
+	placeName?: string,
+	countryCode?: string,
+): { city: string; state: string } | undefined {
+	if (countryCode !== "US" || !placeName) {
+		return undefined;
+	}
+
+	const [city, stateName] = placeName.split(",").map((part) => part.trim());
+	if (!city || !stateName) {
+		return undefined;
+	}
+
+	const normalizedStateName = stateName.toLowerCase();
+	const state =
+		stateName.length === 2
+			? stateName.toUpperCase()
+			: US_STATE_ABBREVIATIONS[normalizedStateName];
+
+	if (!state) {
+		return undefined;
+	}
+
+	return { city, state };
+}
+
+function parseEPALocationTime(timeStr: string, timezone: string): number {
+	const [datePart, hourPart, meridiem] = timeStr.split(" ");
+	const [monthName, dayString, yearString] = datePart.split("/");
+	const month = [
+		"jan",
+		"feb",
+		"mar",
+		"apr",
+		"may",
+		"jun",
+		"jul",
+		"aug",
+		"sep",
+		"oct",
+		"nov",
+		"dec",
+	].indexOf(monthName.slice(0, 3).toLowerCase());
+	const day = Number(dayString);
+	const year = Number(yearString);
+	const hour12 = Number(hourPart);
+	const hour =
+		meridiem === "PM" && hour12 !== 12
+			? hour12 + 12
+			: meridiem === "AM" && hour12 === 12
+				? 0
+				: hour12;
+
+	return new TZDate(year, month, day, hour, 0, 0, timezone).getTime();
+}
+
+export function getWeatherProviderLabel(
+	provider: ActualWeatherProvider,
+): string {
+	switch (provider) {
+		case "google":
+			return "Google";
+		case "epa":
+			return "EPA/NOAA";
+		case "open-meteo":
+			return "Open-Meteo";
+	}
 }

--- a/src/services/weather.ts
+++ b/src/services/weather.ts
@@ -1,9 +1,7 @@
 import { TZDate } from "@date-fns/tz";
-import type { Position, WeatherData, AQIData } from "../types";
+import type { Position, WeatherData, AQIData, WeatherProvider } from "../types";
 import { WMO_DESCRIPTIONS } from "../constants/wmo-descriptions";
 import { fetchAQIData } from "./aqi";
-
-export type WeatherProvider = "open-meteo" | "google";
 
 interface OpenMeteoResponse {
 	elevation: number;
@@ -38,19 +36,22 @@ function parseLocationTime(timeStr: string, timezone: string): number {
 }
 
 export function getActiveWeatherProvider(): WeatherProvider {
+	return isGoogleWeatherTestRoute() ? "google" : "open-meteo";
+}
+
+export function isGoogleWeatherTestRoute(): boolean {
 	if (typeof window === "undefined") {
-		return "open-meteo";
+		return false;
 	}
 
-	return window.location.pathname.replace(/\/+$/, "") === "/google"
-		? "google"
-		: "open-meteo";
+	return window.location.pathname.replace(/\/+$/, "") === "/google";
 }
 
 export async function fetchWeatherData(
 	position: Position,
+	provider: WeatherProvider = getActiveWeatherProvider(),
 ): Promise<WeatherData> {
-	if (getActiveWeatherProvider() === "google") {
+	if (provider === "google") {
 		return fetchGoogleWeatherData(position);
 	}
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -6,6 +6,7 @@ import type {
 	GeolocationState,
 	Position,
 	WeatherData,
+	WeatherProvider,
 } from "./types";
 import {
 	type FitzpatrickType,
@@ -19,6 +20,7 @@ interface AppStore extends AppState {
 	setSkinType: (skinType: FitzpatrickType) => void;
 	setSPFLevel: (spfLevel: SPFLevel) => void;
 	setSweatLevel: (sweatLevel: SweatLevel) => void;
+	setWeatherProvider: (weatherProvider: WeatherProvider) => void;
 	setGeolocationStatus: (status: GeolocationState["status"]) => void;
 	setPosition: (
 		position: Position,
@@ -57,6 +59,19 @@ export const useAppStore = create<AppStore>()(
 				})),
 
 			setSweatLevel: (sweatLevel) => set((state) => ({ ...state, sweatLevel })),
+
+			setWeatherProvider: (weatherProvider) =>
+				set((state) => ({
+					...state,
+					weatherProvider,
+					calculation: undefined,
+					geolocation: {
+						...state.geolocation,
+						weather: undefined,
+						lastFetched: undefined,
+						error: undefined,
+					},
+				})),
 
 			setGeolocationStatus: (status) =>
 				set((state) => ({
@@ -111,6 +126,7 @@ export const useAppStore = create<AppStore>()(
 				skinType: state.skinType,
 				spfLevel: state.spfLevel,
 				sweatLevel: state.sweatLevel,
+				weatherProvider: state.weatherProvider,
 				geolocation:
 					state.geolocation.status === "completed" && state.geolocation.position
 						? {

--- a/src/store.ts
+++ b/src/store.ts
@@ -3,6 +3,7 @@ import { persist } from "zustand/middleware";
 import type {
 	AppState,
 	CalculationResult,
+	EnsembleCalculationResult,
 	GeolocationState,
 	Position,
 	WeatherData,
@@ -28,8 +29,10 @@ interface AppStore extends AppState {
 		countryCode?: string,
 	) => void;
 	setWeather: (weather: WeatherData) => void;
+	setEnsembleWeather: (weather: WeatherData[]) => void;
 	setGeolocationError: (error: string) => void;
 	setCalculation: (calculation: CalculationResult) => void;
+	setEnsembleCalculation: (calculation: EnsembleCalculationResult) => void;
 	clearCalculation: () => void;
 	reset: () => void;
 }
@@ -65,9 +68,11 @@ export const useAppStore = create<AppStore>()(
 					...state,
 					weatherProvider,
 					calculation: undefined,
+					ensembleCalculation: undefined,
 					geolocation: {
 						...state.geolocation,
 						weather: undefined,
+						ensembleWeather: undefined,
 						lastFetched: undefined,
 						error: undefined,
 					},
@@ -97,6 +102,19 @@ export const useAppStore = create<AppStore>()(
 					geolocation: {
 						...state.geolocation,
 						weather,
+						ensembleWeather: undefined,
+						lastFetched: Date.now(),
+						status: "completed",
+					},
+				})),
+
+			setEnsembleWeather: (weather) =>
+				set((state) => ({
+					...state,
+					geolocation: {
+						...state.geolocation,
+						weather: weather[0],
+						ensembleWeather: weather,
 						lastFetched: Date.now(),
 						status: "completed",
 					},
@@ -113,10 +131,25 @@ export const useAppStore = create<AppStore>()(
 				})),
 
 			setCalculation: (calculation) =>
-				set((state) => ({ ...state, calculation })),
+				set((state) => ({
+					...state,
+					calculation,
+					ensembleCalculation: undefined,
+				})),
+
+			setEnsembleCalculation: (ensembleCalculation) =>
+				set((state) => ({
+					...state,
+					calculation: undefined,
+					ensembleCalculation,
+				})),
 
 			clearCalculation: () =>
-				set((state) => ({ ...state, calculation: undefined })),
+				set((state) => ({
+					...state,
+					calculation: undefined,
+					ensembleCalculation: undefined,
+				})),
 
 			reset: () => set(initialState),
 		}),

--- a/src/types.ts
+++ b/src/types.ts
@@ -168,7 +168,7 @@ export interface AQIData {
 }
 
 export interface WeatherData {
-	provider: WeatherProvider;
+	provider: ActualWeatherProvider;
 	current: CurrentWeather;
 	hourly: HourlyWeather[];
 	elevation: number; // meters above sea level
@@ -179,7 +179,8 @@ export interface WeatherData {
 	timezone: string; // IANA timezone string (e.g. "America/Denver")
 }
 
-export type WeatherProvider = "open-meteo" | "google";
+export type ActualWeatherProvider = "open-meteo" | "google" | "epa";
+export type WeatherProvider = ActualWeatherProvider | "ensemble";
 
 // Geographic Position
 export interface Position {
@@ -198,6 +199,7 @@ export interface GeolocationState {
 	placeName?: string;
 	countryCode?: string;
 	weather?: WeatherData;
+	ensembleWeather?: WeatherData[];
 	lastFetched?: number; // timestamp when weather was last fetched
 	error?: string;
 }
@@ -231,6 +233,17 @@ export interface CalculationResult {
 	advice: string[];
 }
 
+export interface ProviderCalculationResult {
+	provider: ActualWeatherProvider;
+	result: CalculationResult;
+}
+
+export interface EnsembleCalculationResult {
+	providers: ProviderCalculationResult[];
+	recommended: ProviderCalculationResult;
+	optimistic?: ProviderCalculationResult;
+}
+
 // App State
 export interface AppState {
 	skinType?: FitzpatrickType;
@@ -239,6 +252,7 @@ export interface AppState {
 	weatherProvider?: WeatherProvider;
 	geolocation: GeolocationState;
 	calculation?: CalculationResult;
+	ensembleCalculation?: EnsembleCalculationResult;
 }
 
 // Constants

--- a/src/types.ts
+++ b/src/types.ts
@@ -168,6 +168,7 @@ export interface AQIData {
 }
 
 export interface WeatherData {
+	provider: WeatherProvider;
 	current: CurrentWeather;
 	hourly: HourlyWeather[];
 	elevation: number; // meters above sea level

--- a/src/types.ts
+++ b/src/types.ts
@@ -178,6 +178,8 @@ export interface WeatherData {
 	timezone: string; // IANA timezone string (e.g. "America/Denver")
 }
 
+export type WeatherProvider = "open-meteo" | "google";
+
 // Geographic Position
 export interface Position {
 	latitude: number;
@@ -233,6 +235,7 @@ export interface AppState {
 	skinType?: FitzpatrickType;
 	spfLevel?: SPFLevel;
 	sweatLevel?: SweatLevel;
+	weatherProvider?: WeatherProvider;
 	geolocation: GeolocationState;
 	calculation?: CalculationResult;
 }

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -2,7 +2,7 @@
 	"compilerOptions": {
 		"tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
 		"target": "ES2023",
-		"lib": ["ES2023"],
+		"lib": ["ES2023", "DOM"],
 		"module": "ESNext",
 		"skipLibCheck": true,
 
@@ -21,5 +21,5 @@
 		"noFallthroughCasesInSwitch": true,
 		"noUncheckedSideEffectImports": true
 	},
-	"include": ["vite.config.ts"]
+	"include": ["vite.config.ts", "api/**/*.ts"]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+	"rewrites": [{ "source": "/google", "destination": "/index.html" }]
+}


### PR DESCRIPTION
## Summary
- Adds a Vercel function at `/api/google-weather` for Google Weather hourly UV forecast data.
- Gates the Google provider behind the `/google` path so the public root route keeps using Open-Meteo.
- Keeps Open-Meteo for elevation, sun timing, and AQI metadata.
- Adds coordinate rounding, in-memory per-IP throttling, and 30-minute cache headers for the Google path.

## Verification
- `bun run check`
- `bun test`
- `bun run build`
- Live function-level test returned status 200 with provider `google`, 24 hourly forecast points, Denver timezone/elevation/AQI metadata, and UV values rising through the day.

## Preview testing
- Set `GOOGLE_MAPS_API_KEY` in Vercel preview/prod env.
- Open the Vercel preview at `/google` to use Google Weather.
- Open the preview root path `/` to confirm Open-Meteo behavior is unchanged.