### PR TITLE
Swap app font to Avio Sans

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,6 @@
       "name": "sunburn-calc",
       "dependencies": {
         "@date-fns/tz": "^1.4.1",
-        "@fontsource/tiktok-sans": "^5.2.2",
         "@radix-ui/react-accordion": "^1.2.11",
         "@radix-ui/react-label": "^2.1.7",
         "@radix-ui/react-progress": "^1.1.7",
@@ -184,8 +183,6 @@
     "@floating-ui/react-dom": ["@floating-ui/react-dom@2.1.4", "", { "dependencies": { "@floating-ui/dom": "^1.7.2" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-JbbpPhp38UmXDDAu60RJmbeme37Jbgsm7NrHGgzYYFKmblzRUh6Pa641dII6LsjwF4XlScDrde2UAzDo/b9KPw=="],
 
     "@floating-ui/utils": ["@floating-ui/utils@0.2.10", "", {}, "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ=="],
-
-    "@fontsource/tiktok-sans": ["@fontsource/tiktok-sans@5.2.2", "", {}, "sha512-L2MKMXpYc3WsnHVpa4AUqzXonKYdsUqcIGILA0Kkoxwa/Xdh1aJuck+a0j6jXoaFK0Zlj1LSbYugc0jtVDh3Ag=="],
 
     "@humanfs/core": ["@humanfs/core@0.19.1", "", {}, "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA=="],
 

--- a/index.html
+++ b/index.html
@@ -12,6 +12,8 @@
     <link rel="preconnect" href="https://api.open-meteo.com" />
     <link rel="preconnect" href="https://air-quality-api.open-meteo.com" />
     <link rel="preconnect" href="https://api.bigdatacloud.net" />
+    <link rel="preconnect" href="https://cdn.aviosans.lerbb.com/" />
+    <link rel="stylesheet" href="https://cdn.aviosans.lerbb.com/avio-sans.css" />
     
     <link rel="canonical" href="https://sunburntimer.com/" />
     <meta name="theme-color" content="#f97316" />

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
 	},
 	"dependencies": {
 		"@date-fns/tz": "^1.4.1",
-		"@fontsource/tiktok-sans": "^5.2.2",
 		"@radix-ui/react-accordion": "^1.2.11",
 		"@radix-ui/react-label": "^2.1.7",
 		"@radix-ui/react-progress": "^1.1.7",

--- a/scripts/generate-og.tsx
+++ b/scripts/generate-og.tsx
@@ -3,11 +3,15 @@ import path from "node:path";
 
 import { ImageResponse } from "@vercel/og";
 
-const fontPath = path.join(
-	process.cwd(),
-	"node_modules/@fontsource/tiktok-sans/files/tiktok-sans-latin-700-normal.woff",
+const fontResponse = await fetch(
+	"https://cdn.aviosans.lerbb.com/fonts/AvioSans-Bold.woff2",
 );
-const fontData = fs.readFileSync(fontPath);
+
+if (!fontResponse.ok) {
+	throw new Error(`Failed to load Avio Sans font: ${fontResponse.status}`);
+}
+
+const fontData = await fontResponse.arrayBuffer();
 
 const image = new ImageResponse(
 	<div
@@ -15,7 +19,7 @@ const image = new ImageResponse(
 			background: "#fff7ed",
 			display: "flex",
 			flexDirection: "column",
-			fontFamily: '"TikTok Sans"',
+			fontFamily: '"Avio Sans"',
 			height: "100%",
 			padding: "80px",
 			position: "relative",
@@ -159,7 +163,7 @@ const image = new ImageResponse(
 	{
 		fonts: [
 			{
-				name: "TikTok Sans",
+				name: "Avio Sans",
 				data: fontData,
 				weight: 700,
 				style: "normal" as const,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,7 +27,6 @@ import {
 	AccordionTrigger,
 } from "./components/ui/accordion";
 import { StepHeader } from "./components/StepHeader";
-import "@fontsource/tiktok-sans/latin.css";
 
 import { Button } from "./components/ui/button";
 import { Badge } from "@/components/ui/badge";

--- a/src/index.css
+++ b/src/index.css
@@ -8,7 +8,7 @@
 	--radius-md: calc(var(--radius) - 2px);
 	--radius-lg: var(--radius);
 	--radius-xl: calc(var(--radius) + 4px);
-	--default-font-family: "TikTok Sans", ui-sans-serif, system-ui, sans-serif;
+	--default-font-family: "Avio Sans", ui-sans-serif, system-ui, sans-serif;
 	--color-background: var(--background);
 	--color-foreground: var(--foreground);
 	--color-card: var(--card);


### PR DESCRIPTION
## Summary
- load Avio Sans from the provided CDN stylesheet
- update Tailwind's default font family to Avio Sans
- remove the old TikTok Sans fontsource dependency and update the OG generator font reference

## Verification
- bun run check
- bun run build

Note: I did not regenerate public/ogimage.png because the existing generator script cannot run without @vercel/og installed.