### PR TITLE
Improve sun exposure planning and UV modeling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ dist-ssr
 *.local
 .serena/
 .playwright-mcp/
+.playwright-cli/
 .vercel/
 
 # Editor directories and files

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@ node_modules
 dist
 dist-ssr
 *.local
+.serena/
+.playwright-mcp/
+.vercel/
 
 # Editor directories and files
 .vscode/*
@@ -24,3 +27,4 @@ dist-ssr
 *.sw?
 
 .env
+.vercel

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SunburnTimer - Smart Sun Exposure Calculator
 
-A modern web application that calculates safe sun exposure time based on your skin type, SPF protection, sweating level, and real-time weather data. Built with React, TypeScript, and modern tooling.
+A modern web application that estimates sun exposure time based on your skin type, SPF protection, sweating level, planned start time, activity length, and live weather data. Built with React, TypeScript, and modern tooling.
 
 ## Features
 
@@ -8,7 +8,15 @@ A modern web application that calculates safe sun exposure time based on your sk
 - **SPF Protection Modeling**: Account for different sunscreen strengths and degradation over time
 - **Activity Level Consideration**: Factor in sweating that reduces SPF effectiveness
 - **Real-time Weather Data**: Uses Open-Meteo API for UV index and weather conditions
+- **Plan Ahead**: Choose "now" or a later start time before you go outside
+- **Visible Unit Switching**: Switch between Fahrenheit/miles and Celsius/kilometers from the main planner
+- **SPF Recommendation**: Enter time outside and a skin-change goal to get a suggested SPF level
+- **Estimate Caveats**: Shows clear notes and source links because UV risk varies by person and conditions
 - **Interactive Visualization**: Chart.js displays skin damage accumulation over time
+- **Activity-Focused UV Chart**: Shows UV for the planned activity window by default, with a local-day view for context
+- **Current UV Anchoring**: Uses the observed current UV reading for the first forecast segment when it differs from hourly forecast data
+- **Skin Recovery Model**: Uses a leaky-bucket recovery model so long low-UV gaps can reduce accumulated burn risk
+- **Google Weather Preview**: `/google` can switch to Google Weather through a Vercel function when `GOOGLE_MAPS_API_KEY` is configured
 - **Location Services**: Support for both GPS location and manual address entry
 - **Responsive Design**: Beautiful UI built with shadcn/ui components
 - **Progressive Web App Ready**: Modern architecture with offline capabilities
@@ -18,17 +26,19 @@ A modern web application that calculates safe sun exposure time based on your sk
 This implementation fixes critical bugs from the original OCaml version:
 
 - **UV Interpolation Fix**: Corrects integer division bug that caused up to 89% error in calculations
+- **Observed UV Anchoring**: Anchors the first active segment to the live UV reading instead of blindly trusting the hourly forecast point
+- **Leaky-Bucket Recovery**: Applies slow UVB recovery over roughly 24-30 hours, so damage can drain during long no-UV breaks
 - **SPF Degradation Modeling**: Proper lower bounds to prevent negative protection values
 - **Time-based Calculations**: Accurate UV scaling and damage accumulation algorithms
 
 ## Technology Stack
 
-- **Frontend**: React 18, TypeScript, Vite
+- **Frontend**: React 19, TypeScript, Vite
 - **UI Components**: shadcn/ui, Tailwind CSS
 - **State Management**: Zustand with persistence
 - **Charts**: Chart.js with react-chartjs-2
 - **APIs**: Open-Meteo, BigDataCloud Geocoding
-- **Build Tools**: Vite, ESLint, TypeScript
+- **Build Tools**: Vite, Biome, TypeScript
 
 ## Getting Started
 
@@ -42,21 +52,17 @@ This implementation fixes critical bugs from the original OCaml version:
 1. **Clone the repository**
    ```bash
    git clone <repository-url>
-   cd sunburn-calc
+   cd sunburntimer
    ```
 
 2. **Install dependencies**
    ```bash
    bun install
-   # or
-   npm install
    ```
 
 3. **Start the development server**
    ```bash
    bun dev
-   # or
-   npm run dev
    ```
 
 4. **Open your browser**
@@ -66,17 +72,23 @@ This implementation fixes critical bugs from the original OCaml version:
 
 ```bash
 bun run build
-# or
-npm run build
 ```
 
 ## Usage
 
-1. **Select Your Skin Type**: Choose from the Fitzpatrick scale (I-VI) based on your skin's reaction to sun exposure
-2. **Choose SPF Level**: Select your sunscreen's SPF rating or "None" if not using sunscreen
-3. **Set Activity Level**: Indicate how much you'll be sweating (affects SPF degradation)
-4. **Set Location**: Use GPS or enter a city/address for weather data
-5. **Calculate**: Get your personalized burn time and safety recommendations
+1. **Plan the outing**: Choose now or later, set time outside, pick units, and choose your skin-change goal
+2. **Select Your Skin Type**: Choose from the Fitzpatrick scale (I-VI) based on your skin's reaction to sun exposure
+3. **Choose SPF Level**: Select your sunscreen's SPF rating or "None" if not using sunscreen
+4. **Set Activity Level**: Indicate how much you'll be sweating, because this affects SPF wear-off
+5. **Set Location**: Use GPS or enter a city/address for weather data
+6. **Review the result**: Check burn time, estimated dose, charts, and the recommended SPF for your plan
+7. **Inspect UV timing**: Use the UV chart's Activity view for your planned timespan or Day view for the same local calendar day
+
+## Estimate Notes
+
+SunburnTimer gives estimates, not medical advice. A tan means UV exposure and skin damage risk, even if the app labels a goal as "light tan" or "more tan". The SPF recommendation uses forecast UV Index, Fitzpatrick skin type, sunscreen level, sweat wear-off, and planned time outside to choose a protection level that fits the selected risk budget.
+
+The app links to CDC, FDA, and American Academy of Dermatology guidance in the planner. Their guidance is still simple: protect skin from UV, use broad-spectrum sunscreen, reapply it at least every 2 hours, and reapply after sweating, swimming, or towel drying.
 
 ## Core Algorithm
 
@@ -104,6 +116,7 @@ src/
 │   ├── SPFSelector.tsx
 │   ├── SweatLevelSelector.tsx
 │   ├── LocationSelector.tsx
+│   ├── PlanControls.tsx
 │   ├── ResultsDisplay.tsx
 │   ├── BurnChart.tsx
 │   ├── UVChart.tsx
@@ -115,8 +128,12 @@ src/
 │   └── useLocationRefresh.ts
 ├── services/           # External API services
 │   ├── weather.ts      # Open-Meteo integration
-│   └── geolocation.ts  # GPS and BigDataCloud geocoding
+│   ├── geolocation.ts  # GPS and BigDataCloud geocoding
+│   ├── geocoding.ts    # Manual location search
+│   └── aqi.ts          # Air quality data
 ├── lib/               # Utility functions
+│   ├── units.ts
+│   ├── uvSeries.ts
 │   └── utils.ts
 ├── store.ts           # Zustand state management
 ├── types.ts           # TypeScript definitions
@@ -131,6 +148,12 @@ src/
 - **Endpoint**: Free Weather API
 - **Data**: Current weather, hourly forecasts, UV index
 - **Rate Limits**: No API key required, generous free tier
+
+### Google Weather Preview
+- **Endpoint**: Google Weather hourly forecast API through `/api/google-weather`
+- **Route**: Open `/google` to reveal the provider switch
+- **Requirement**: Set `GOOGLE_MAPS_API_KEY` in Vercel preview or production
+- **Notes**: Open-Meteo is still used for elevation, sun timing, and AQI metadata
 
 ### BigDataCloud
 - **Endpoint**: Free Reverse Geocoding API
@@ -167,6 +190,8 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 ## Acknowledgments
 
 - Based on the original OCaml sunburn calculator
+- Original app by [Jon Callahan](https://joncallahan.com) in [jondcallahan/sunburntimer](https://github.com/jondcallahan/sunburntimer)
+- Additions by [@coloboxp](https://github.com/coloboxp)
 - Fitzpatrick skin type scale for scientific accuracy
 - Open-Meteo and BigDataCloud for reliable, free data services
 - shadcn/ui for beautiful, accessible components

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A modern web application that estimates sun exposure time based on your skin typ
 - **Fitzpatrick Skin Type Selection**: Choose from 6 scientifically-based skin types
 - **SPF Protection Modeling**: Account for different sunscreen strengths and degradation over time
 - **Activity Level Consideration**: Factor in sweating that reduces SPF effectiveness
-- **Real-time Weather Data**: Uses Open-Meteo API for UV index and weather conditions
+- **Real-time Weather Data**: Uses Open-Meteo API for UV index and weather conditions through a same-origin Vercel function in production, with a CurrentUVIndex + MET Norway fallback
 - **Plan Ahead**: Choose "now" or a later start time before you go outside
 - **Visible Unit Switching**: Switch between Fahrenheit/miles and Celsius/kilometers from the main planner
 - **SPF Recommendation**: Enter time outside and a skin-change goal to get a suggested SPF level
@@ -37,7 +37,7 @@ This implementation fixes critical bugs from the original OCaml version:
 - **UI Components**: shadcn/ui, Tailwind CSS
 - **State Management**: Zustand with persistence
 - **Charts**: Chart.js with react-chartjs-2
-- **APIs**: Open-Meteo, BigDataCloud Geocoding
+- **APIs**: Open-Meteo, BigDataCloud Geocoding, CurrentUVIndex, MET Norway, Vercel functions
 - **Build Tools**: Vite, Biome, TypeScript
 
 ## Getting Started
@@ -127,7 +127,7 @@ src/
 │   ├── useCurrentTime.ts
 │   └── useLocationRefresh.ts
 ├── services/           # External API services
-│   ├── weather.ts      # Open-Meteo integration
+│   ├── weather.ts      # Open-Meteo and Google weather integration
 │   ├── geolocation.ts  # GPS and BigDataCloud geocoding
 │   ├── geocoding.ts    # Manual location search
 │   └── aqi.ts          # Air quality data
@@ -145,9 +145,10 @@ src/
 ## API Integration
 
 ### Open-Meteo
-- **Endpoint**: Free Weather API
+- **Endpoint**: Free Weather API through `/api/open-meteo-weather` in production
 - **Data**: Current weather, hourly forecasts, UV index
 - **Rate Limits**: No API key required, generous free tier
+- **Notes**: The browser uses the same-origin function first to avoid third-party CORS failures, then falls back to direct Open-Meteo in plain local Vite development. If Open-Meteo is unavailable in production, the server uses CurrentUVIndex for UV data and MET Norway for temperature/weather.
 
 ### Google Weather Preview
 - **Endpoint**: Google Weather hourly forecast API through `/api/google-weather`
@@ -160,9 +161,13 @@ src/
 - **Features**: Location-based city/country lookup
 - **Rate Limits**: No API key required, free tier available
 
+### Fallback Weather Sources
+- **CurrentUVIndex**: No-key UV Index forecast fallback with attribution link shown in the weather card when active
+- **MET Norway**: No-key temperature and condition fallback used with a clear User-Agent header
+
 ## Security & Privacy
 
-- No API keys required - uses free public APIs
+- No API keys required for the default Open-Meteo flow
 - No personal data is stored on servers
 - User preferences saved locally with Zustand persist
 - HTTPS enforced for all API calls
@@ -194,6 +199,7 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 - Additions by [@coloboxp](https://github.com/coloboxp)
 - Fitzpatrick skin type scale for scientific accuracy
 - Open-Meteo and BigDataCloud for reliable, free data services
+- CurrentUVIndex and MET Norway for no-key fallback weather data
 - shadcn/ui for beautiful, accessible components
 
 ## Support

--- a/TODO.md
+++ b/TODO.md
@@ -6,6 +6,7 @@
 - Check whether users prefer Activity or Day as the saved default for the UV chart after a few real use cases.
 - Decide whether to publish a maintained fork, gist, or static deployment before creating an external public copy.
 - Test `/google` in Vercel preview with a real `GOOGLE_MAPS_API_KEY`; plain Vite dev cannot serve the provider function.
+- Watch the Open-Meteo proxy route in production logs after launch, because it now protects the default GPS flow from browser CORS failures and falls back to CurrentUVIndex + MET Norway when Open-Meteo is unavailable.
 - Consider adding activity presets like walking, running, cycling, and beach day if users need faster setup.
 - Consider showing a small SPF option table so users can compare dose for None, SPF 15, SPF 30, and SPF 50+.
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,16 @@
+# TODO
+
+## Current UX Follow-Up
+
+- Verify the compact planner on real mobile devices after the browser pass.
+- Check whether users prefer Activity or Day as the saved default for the UV chart after a few real use cases.
+- Decide whether to publish a maintained fork, gist, or static deployment before creating an external public copy.
+- Test `/google` in Vercel preview with a real `GOOGLE_MAPS_API_KEY`; plain Vite dev cannot serve the provider function.
+- Consider adding activity presets like walking, running, cycling, and beach day if users need faster setup.
+- Consider showing a small SPF option table so users can compare dose for None, SPF 15, SPF 30, and SPF 50+.
+
+## Product Risks
+
+- SPF and tanning guidance must stay clearly marked as an estimate.
+- Tanning goals should never be described as safe. They are only risk budgets for UV exposure.
+- Weather forecast coverage is limited, so long future plans need a visible warning.

--- a/api/google-weather.ts
+++ b/api/google-weather.ts
@@ -1,0 +1,433 @@
+import { TZDate } from "@date-fns/tz";
+
+type WeatherOverview = {
+	id: number;
+	main: string;
+	description: string;
+	icon: string;
+};
+
+type WeatherData = {
+	provider: "google";
+	current: {
+		dt: number;
+		temp: number;
+		uvi: number;
+		weather: WeatherOverview[];
+	};
+	hourly: Array<{
+		dt: number;
+		temp: number;
+		uvi: number;
+		weather: WeatherOverview[];
+	}>;
+	elevation: number;
+	aqi?: {
+		us_aqi: number;
+	};
+	sunrise: string;
+	sunset: string;
+	nextSunrise: string;
+	timezone: string;
+};
+
+type GoogleForecastHour = {
+	interval?: {
+		startTime?: string;
+	};
+	weatherCondition?: {
+		iconBaseUri?: string;
+		type?: string;
+		description?: {
+			text?: string;
+		};
+	};
+	temperature?: {
+		degrees?: number;
+	};
+	uvIndex?: number;
+};
+
+type GoogleHourlyResponse = {
+	forecastHours?: GoogleForecastHour[];
+	timeZone?: {
+		id?: string;
+	};
+	nextPageToken?: string;
+};
+
+type OpenMeteoMetadataResponse = {
+	elevation?: number;
+	timezone?: string;
+	daily?: {
+		sunrise?: string[];
+		sunset?: string[];
+	};
+};
+
+type OpenMeteoAqiResponse = {
+	current?: {
+		us_aqi?: number;
+	};
+};
+
+type RateLimitEntry = {
+	windowStart: number;
+	count: number;
+};
+
+const GOOGLE_WEATHER_BASE_URL =
+	"https://weather.googleapis.com/v1/forecast/hours:lookup";
+const OPEN_METEO_FORECAST_URL = "https://api.open-meteo.com/v1/forecast";
+const OPEN_METEO_AQI_URL =
+	"https://air-quality-api.open-meteo.com/v1/air-quality";
+const FORECAST_DAYS = 3;
+const MAX_GOOGLE_FORECAST_HOURS = 72;
+const RATE_LIMIT_WINDOW_MS = 60 * 60 * 1000;
+const RATE_LIMIT_MAX = 30;
+
+const globalRuntime = globalThis as typeof globalThis & {
+	__sunburnGoogleWeatherRateLimit?: Map<string, RateLimitEntry>;
+};
+
+const rateLimit =
+	globalRuntime.__sunburnGoogleWeatherRateLimit ??
+	new Map<string, RateLimitEntry>();
+
+globalRuntime.__sunburnGoogleWeatherRateLimit = rateLimit;
+
+export default {
+	async fetch(request: Request): Promise<Response> {
+		if (request.method !== "GET") {
+			return jsonResponse({ error: "Method not allowed" }, 405);
+		}
+
+		if (!isAllowedGoogleTestRequest(request)) {
+			return jsonResponse({ error: "Google weather test route required" }, 403);
+		}
+
+		const rateLimitResponse = checkRateLimit(request);
+		if (rateLimitResponse) {
+			return rateLimitResponse;
+		}
+
+		const apiKey = process.env.GOOGLE_MAPS_API_KEY;
+		if (!apiKey) {
+			return jsonResponse({ error: "Missing GOOGLE_MAPS_API_KEY" }, 500);
+		}
+
+		const url = new URL(request.url);
+		const latitude = parseCoordinate(url.searchParams.get("latitude"), -90, 90);
+		const longitude = parseCoordinate(
+			url.searchParams.get("longitude"),
+			-180,
+			180,
+		);
+
+		if (latitude === undefined || longitude === undefined) {
+			return jsonResponse(
+				{ error: "Valid latitude and longitude are required" },
+				400,
+			);
+		}
+
+		try {
+			const [googleWeather, metadata, aqi] = await Promise.all([
+				fetchGoogleHourlyWeather(apiKey, latitude, longitude),
+				fetchOpenMeteoMetadata(latitude, longitude),
+				fetchOpenMeteoAqi(latitude, longitude),
+			]);
+			const weather = normalizeWeatherData(googleWeather, metadata, aqi);
+
+			return weatherResponse(weather);
+		} catch (error) {
+			return jsonResponse(
+				{
+					error:
+						error instanceof Error
+							? error.message
+							: "Failed to fetch Google weather",
+				},
+				502,
+			);
+		}
+	},
+};
+
+function isAllowedGoogleTestRequest(request: Request): boolean {
+	if (process.env.NODE_ENV !== "production") {
+		return true;
+	}
+
+	const referer = request.headers.get("referer");
+	if (!referer) {
+		return false;
+	}
+
+	try {
+		return new URL(referer).pathname.replace(/\/+$/, "") === "/google";
+	} catch {
+		return false;
+	}
+}
+
+function checkRateLimit(request: Request): Response | undefined {
+	const ipAddress = getIpAddress(request);
+	const now = Date.now();
+	const entry = rateLimit.get(ipAddress);
+
+	if (!entry || now - entry.windowStart >= RATE_LIMIT_WINDOW_MS) {
+		rateLimit.set(ipAddress, { windowStart: now, count: 1 });
+		return undefined;
+	}
+
+	entry.count += 1;
+	if (entry.count > RATE_LIMIT_MAX) {
+		return jsonResponse(
+			{ error: "Too many Google weather requests. Please try again later." },
+			429,
+			{
+				"Retry-After": Math.ceil(
+					(RATE_LIMIT_WINDOW_MS - (now - entry.windowStart)) / 1000,
+				).toString(),
+			},
+		);
+	}
+
+	return undefined;
+}
+
+function getIpAddress(request: Request): string {
+	return (
+		request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
+		request.headers.get("x-real-ip") ||
+		"unknown"
+	);
+}
+
+function parseCoordinate(
+	value: string | null,
+	min: number,
+	max: number,
+): number | undefined {
+	if (!value) return undefined;
+
+	const coordinate = Number(value);
+	if (!Number.isFinite(coordinate) || coordinate < min || coordinate > max) {
+		return undefined;
+	}
+
+	return coordinate;
+}
+
+async function fetchGoogleHourlyWeather(
+	apiKey: string,
+	latitude: number,
+	longitude: number,
+): Promise<GoogleHourlyResponse> {
+	let nextPageToken: string | undefined;
+	let timeZone: GoogleHourlyResponse["timeZone"];
+	const forecastHours: GoogleForecastHour[] = [];
+
+	do {
+		const page = await fetchGoogleHourlyWeatherPage(
+			apiKey,
+			latitude,
+			longitude,
+			nextPageToken,
+		);
+		timeZone ??= page.timeZone;
+		forecastHours.push(...(page.forecastHours ?? []));
+		nextPageToken = page.nextPageToken;
+	} while (nextPageToken && forecastHours.length < MAX_GOOGLE_FORECAST_HOURS);
+
+	return {
+		forecastHours: forecastHours.slice(0, MAX_GOOGLE_FORECAST_HOURS),
+		timeZone,
+	};
+}
+
+async function fetchGoogleHourlyWeatherPage(
+	apiKey: string,
+	latitude: number,
+	longitude: number,
+	pageToken?: string,
+): Promise<GoogleHourlyResponse> {
+	const url = new URL(GOOGLE_WEATHER_BASE_URL);
+	const params = new URLSearchParams({
+		key: apiKey,
+		"location.latitude": latitude.toString(),
+		"location.longitude": longitude.toString(),
+		unitsSystem: "IMPERIAL",
+		hours: MAX_GOOGLE_FORECAST_HOURS.toString(),
+		pageSize: "24",
+		languageCode: "en",
+	});
+
+	if (pageToken) {
+		params.set("pageToken", pageToken);
+	}
+
+	url.search = params.toString();
+
+	const response = await fetch(url);
+	if (!response.ok) {
+		throw new Error(
+			`Google Weather API error: ${response.status} ${response.statusText}`,
+		);
+	}
+
+	return response.json();
+}
+
+async function fetchOpenMeteoMetadata(
+	latitude: number,
+	longitude: number,
+): Promise<OpenMeteoMetadataResponse> {
+	const url = new URL(OPEN_METEO_FORECAST_URL);
+	url.search = new URLSearchParams({
+		latitude: latitude.toString(),
+		longitude: longitude.toString(),
+		daily: "sunrise,sunset",
+		forecast_days: FORECAST_DAYS.toString(),
+		timezone: "auto",
+	}).toString();
+
+	const response = await fetch(url);
+	if (!response.ok) {
+		throw new Error(
+			`Open-Meteo metadata error: ${response.status} ${response.statusText}`,
+		);
+	}
+
+	return response.json();
+}
+
+async function fetchOpenMeteoAqi(
+	latitude: number,
+	longitude: number,
+): Promise<OpenMeteoAqiResponse | undefined> {
+	const url = new URL(OPEN_METEO_AQI_URL);
+	url.search = new URLSearchParams({
+		latitude: latitude.toString(),
+		longitude: longitude.toString(),
+		current: "us_aqi",
+		domains: "cams_global",
+	}).toString();
+
+	const response = await fetch(url);
+	if (!response.ok) {
+		return undefined;
+	}
+
+	return response.json();
+}
+
+function normalizeWeatherData(
+	googleWeather: GoogleHourlyResponse,
+	metadata: OpenMeteoMetadataResponse,
+	aqi: OpenMeteoAqiResponse | undefined,
+): WeatherData {
+	const timezone = googleWeather.timeZone?.id || metadata.timezone;
+	if (!timezone) {
+		throw new Error("Missing weather timezone");
+	}
+
+	const hourly = (googleWeather.forecastHours ?? []).flatMap((hour) => {
+		const startTime = hour.interval?.startTime;
+		const temperature = hour.temperature?.degrees;
+		const uvIndex = hour.uvIndex;
+
+		if (
+			!startTime ||
+			typeof temperature !== "number" ||
+			typeof uvIndex !== "number"
+		) {
+			return [];
+		}
+
+		return [
+			{
+				dt: Math.floor(Date.parse(startTime) / 1000),
+				temp: temperature,
+				uvi: uvIndex,
+				weather: [normalizeWeatherOverview(hour)],
+			},
+		];
+	});
+	const filteredHourly = hourly.slice(0, MAX_GOOGLE_FORECAST_HOURS);
+	const current = filteredHourly[0];
+	if (!current) {
+		throw new Error("Invalid Google weather data received");
+	}
+
+	const sunrise = metadata.daily?.sunrise?.[0];
+	const sunset = metadata.daily?.sunset?.[0];
+	const nextSunrise = metadata.daily?.sunrise?.[1];
+	if (!sunrise || !sunset || !nextSunrise) {
+		throw new Error("Missing sunrise or sunset metadata");
+	}
+
+	return {
+		provider: "google",
+		current,
+		hourly: filteredHourly,
+		elevation: metadata.elevation ?? 0,
+		aqi:
+			typeof aqi?.current?.us_aqi === "number"
+				? { us_aqi: Math.round(aqi.current.us_aqi) }
+				: undefined,
+		sunrise: new Date(parseLocationTime(sunrise, timezone)).toISOString(),
+		sunset: new Date(parseLocationTime(sunset, timezone)).toISOString(),
+		nextSunrise: new Date(
+			parseLocationTime(nextSunrise, timezone),
+		).toISOString(),
+		timezone,
+	};
+}
+
+function parseLocationTime(timeStr: string, timezone: string): number {
+	const [datePart, timePart] = timeStr.split("T");
+	const [year, month, day] = datePart.split("-").map(Number);
+	const [hour, minute] = (timePart ?? "00:00").split(":").map(Number);
+
+	return new TZDate(year, month - 1, day, hour, minute, 0, timezone).getTime();
+}
+
+function normalizeWeatherOverview(hour: GoogleForecastHour): WeatherOverview {
+	const type = hour.weatherCondition?.type ?? "UNKNOWN";
+	const description =
+		hour.weatherCondition?.description?.text ?? type.replaceAll("_", " ");
+
+	return {
+		id: 800,
+		main: toTitleCase(type.replaceAll("_", " ").toLowerCase()),
+		description,
+		icon: hour.weatherCondition?.iconBaseUri ?? "",
+	};
+}
+
+function toTitleCase(value: string): string {
+	return value.replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+function weatherResponse(body: WeatherData): Response {
+	return jsonResponse(body, 200, {
+		"Cache-Control": "no-store",
+		"X-Weather-Provider": "google",
+	});
+}
+
+function jsonResponse(
+	body: unknown,
+	status: number,
+	headers?: Record<string, string>,
+): Response {
+	return Response.json(body, {
+		status,
+		headers: {
+			...headers,
+			"Content-Type": "application/json",
+		},
+	});
+}

--- a/api/open-meteo-weather.ts
+++ b/api/open-meteo-weather.ts
@@ -1,0 +1,725 @@
+import { TZDate } from "@date-fns/tz";
+import { WMO_DESCRIPTIONS } from "../src/constants/wmo-descriptions.js";
+
+type WeatherOverview = {
+	id: number;
+	main: string;
+	description: string;
+	icon: string;
+};
+
+type WeatherProvider = "open-meteo" | "current-uv-index";
+
+type WeatherData = {
+	provider: WeatherProvider;
+	current: {
+		dt: number;
+		temp: number;
+		uvi: number;
+		weather: WeatherOverview[];
+	};
+	hourly: Array<{
+		dt: number;
+		temp: number;
+		uvi: number;
+		weather: WeatherOverview[];
+	}>;
+	elevation: number;
+	aqi?: {
+		us_aqi: number;
+	};
+	sunrise: string;
+	sunset: string;
+	nextSunrise: string;
+	timezone: string;
+};
+
+type OpenMeteoResponse = {
+	elevation: number;
+	timezone: string;
+	current?: {
+		time?: string;
+		temperature_2m?: number;
+		uv_index?: number;
+		weather_code?: number;
+	};
+	hourly?: {
+		time?: string[];
+		temperature_2m?: number[];
+		uv_index?: number[];
+		weather_code?: number[];
+	};
+	daily?: {
+		sunrise?: string[];
+		sunset?: string[];
+	};
+};
+
+type OpenMeteoAqiResponse = {
+	current?: {
+		us_aqi?: number;
+	};
+};
+
+type CurrentUvIndexPoint = {
+	time: string;
+	uvi: number;
+};
+
+type CurrentUvIndexResponse =
+	| {
+			ok: true;
+			now: CurrentUvIndexPoint;
+			forecast: CurrentUvIndexPoint[];
+			history?: CurrentUvIndexPoint[];
+	  }
+	| {
+			ok: false;
+			message?: string;
+	  };
+
+type MetNoTimeseries = {
+	time?: string;
+	data?: {
+		instant?: {
+			details?: {
+				air_temperature?: number;
+			};
+		};
+		next_1_hours?: {
+			summary?: {
+				symbol_code?: string;
+			};
+		};
+		next_6_hours?: {
+			summary?: {
+				symbol_code?: string;
+			};
+		};
+		next_12_hours?: {
+			summary?: {
+				symbol_code?: string;
+			};
+		};
+	};
+};
+
+type MetNoResponse = {
+	geometry?: {
+		coordinates?: number[];
+	};
+	properties?: {
+		timeseries?: MetNoTimeseries[];
+	};
+};
+
+type MetNoPoint = {
+	timeMs: number;
+	temp: number;
+	symbolCode?: string;
+};
+
+const OPEN_METEO_FORECAST_URL = "https://api.open-meteo.com/v1/forecast";
+const OPEN_METEO_AQI_URL =
+	"https://air-quality-api.open-meteo.com/v1/air-quality";
+const CURRENT_UV_INDEX_URL = "https://currentuvindex.com/api/v1/uvi";
+const MET_NO_FORECAST_URL =
+	"https://api.met.no/weatherapi/locationforecast/2.0/compact";
+const FORECAST_DAYS = 3;
+const HOUR_MS = 60 * 60 * 1000;
+const DAY_MS = 24 * HOUR_MS;
+
+export default {
+	async fetch(request: Request): Promise<Response> {
+		if (request.method !== "GET") {
+			return jsonResponse({ error: "Method not allowed" }, 405);
+		}
+
+		const url = new URL(request.url);
+		const latitude = parseCoordinate(url.searchParams.get("latitude"), -90, 90);
+		const longitude = parseCoordinate(
+			url.searchParams.get("longitude"),
+			-180,
+			180,
+		);
+
+		if (latitude === undefined || longitude === undefined) {
+			return jsonResponse(
+				{ error: "Valid latitude and longitude are required" },
+				400,
+			);
+		}
+
+		try {
+			const [forecast, aqi] = await Promise.all([
+				fetchOpenMeteoForecast(latitude, longitude),
+				fetchOpenMeteoAqi(latitude, longitude),
+			]);
+
+			return weatherResponse(normalizeOpenMeteoWeatherData(forecast, aqi));
+		} catch (openMeteoError) {
+			try {
+				const timezone = parseTimezone(
+					url.searchParams.get("timezone"),
+					longitude,
+				);
+				const fallbackWeather = await fetchUvFallbackWeather(
+					latitude,
+					longitude,
+					timezone,
+				);
+
+				return weatherResponse(fallbackWeather);
+			} catch (fallbackError) {
+				const openMeteoMessage =
+					openMeteoError instanceof Error
+						? openMeteoError.message
+						: "Failed to fetch Open-Meteo weather";
+				const fallbackMessage =
+					fallbackError instanceof Error
+						? fallbackError.message
+						: "fallback weather also failed";
+
+				return jsonResponse(
+					{
+						error: `${openMeteoMessage}. Fallback weather also failed: ${fallbackMessage}`,
+					},
+					502,
+				);
+			}
+		}
+	},
+};
+
+function parseTimezone(value: string | null, longitude: number): string {
+	if (!value) {
+		return getApproximateTimezone(longitude);
+	}
+
+	try {
+		new Intl.DateTimeFormat("en", { timeZone: value }).format();
+		if (!isTimezoneReasonableForLongitude(value, longitude)) {
+			return getApproximateTimezone(longitude);
+		}
+
+		return value;
+	} catch {
+		return getApproximateTimezone(longitude);
+	}
+}
+
+function isTimezoneReasonableForLongitude(
+	timezone: string,
+	longitude: number,
+): boolean {
+	const offsetHours = getTimezoneOffsetHours(timezone);
+	if (offsetHours === undefined) {
+		return true;
+	}
+
+	const expectedLongitude = offsetHours * 15;
+	const delta = Math.abs(
+		normalizeLongitudeDelta(longitude - expectedLongitude),
+	);
+	return delta <= 45;
+}
+
+function getTimezoneOffsetHours(timezone: string): number | undefined {
+	const timezoneName = new Intl.DateTimeFormat("en", {
+		timeZone: timezone,
+		timeZoneName: "shortOffset",
+	})
+		.formatToParts(new Date())
+		.find((part) => part.type === "timeZoneName")?.value;
+	if (!timezoneName) {
+		return undefined;
+	}
+
+	if (timezoneName === "GMT" || timezoneName === "UTC") {
+		return 0;
+	}
+
+	const match =
+		/^GMT(?<sign>[+-])(?<hours>\d{1,2})(?::(?<minutes>\d{2}))?$/.exec(
+			timezoneName,
+		);
+	if (!match?.groups) {
+		return undefined;
+	}
+
+	const sign = match.groups.sign === "-" ? -1 : 1;
+	const hours = Number(match.groups.hours);
+	const minutes = Number(match.groups.minutes ?? "0");
+	if (!Number.isFinite(hours) || !Number.isFinite(minutes)) {
+		return undefined;
+	}
+
+	return sign * (hours + minutes / 60);
+}
+
+function normalizeLongitudeDelta(delta: number): number {
+	let normalized = delta;
+	while (normalized > 180) normalized -= 360;
+	while (normalized < -180) normalized += 360;
+	return normalized;
+}
+
+function getApproximateTimezone(longitude: number): string {
+	const offset = Math.max(-12, Math.min(14, Math.round(longitude / 15)));
+	if (offset === 0) {
+		return "UTC";
+	}
+
+	return `Etc/GMT${offset > 0 ? "-" : "+"}${Math.abs(offset)}`;
+}
+
+function parseCoordinate(
+	value: string | null,
+	min: number,
+	max: number,
+): number | undefined {
+	if (!value) return undefined;
+
+	const coordinate = Number(value);
+	if (!Number.isFinite(coordinate) || coordinate < min || coordinate > max) {
+		return undefined;
+	}
+
+	return coordinate;
+}
+
+async function fetchWithTimeout(
+	input: string | URL,
+	init?: RequestInit,
+	timeoutMs = 8000,
+): Promise<Response> {
+	const controller = new AbortController();
+	const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+	try {
+		return await fetch(input, {
+			...init,
+			signal: controller.signal,
+		});
+	} finally {
+		clearTimeout(timeout);
+	}
+}
+
+async function fetchOpenMeteoForecast(
+	latitude: number,
+	longitude: number,
+): Promise<OpenMeteoResponse> {
+	const url = new URL(OPEN_METEO_FORECAST_URL);
+	url.search = new URLSearchParams({
+		latitude: latitude.toFixed(4),
+		longitude: longitude.toFixed(4),
+		current: "temperature_2m,uv_index,weather_code",
+		hourly: "temperature_2m,uv_index,weather_code",
+		daily: "sunrise,sunset",
+		temperature_unit: "fahrenheit",
+		wind_speed_unit: "mph",
+		timezone: "auto",
+		forecast_days: FORECAST_DAYS.toString(),
+	}).toString();
+
+	const response = await fetchWithTimeout(url);
+	if (!response.ok) {
+		throw new Error(
+			`Open-Meteo forecast error: ${response.status} ${response.statusText}`,
+		);
+	}
+
+	return response.json();
+}
+
+async function fetchOpenMeteoAqi(
+	latitude: number,
+	longitude: number,
+): Promise<OpenMeteoAqiResponse | undefined> {
+	const url = new URL(OPEN_METEO_AQI_URL);
+	url.search = new URLSearchParams({
+		latitude: latitude.toFixed(4),
+		longitude: longitude.toFixed(4),
+		current: "us_aqi",
+		domains: "cams_global",
+	}).toString();
+
+	const response = await fetchWithTimeout(url);
+	if (!response.ok) {
+		return undefined;
+	}
+
+	return response.json();
+}
+
+async function fetchUvFallbackWeather(
+	latitude: number,
+	longitude: number,
+	timezone: string,
+): Promise<WeatherData> {
+	const [uvIndex, metNo] = await Promise.all([
+		fetchCurrentUvIndex(latitude, longitude),
+		fetchMetNoForecast(latitude, longitude),
+	]);
+
+	return normalizeUvFallbackWeatherData(uvIndex, metNo, timezone);
+}
+
+async function fetchCurrentUvIndex(
+	latitude: number,
+	longitude: number,
+): Promise<CurrentUvIndexResponse> {
+	const url = new URL(CURRENT_UV_INDEX_URL);
+	url.search = new URLSearchParams({
+		latitude: latitude.toString(),
+		longitude: longitude.toString(),
+	}).toString();
+
+	const response = await fetchWithTimeout(url, {
+		headers: {
+			Accept: "application/json",
+		},
+	});
+	if (!response.ok) {
+		throw new Error(
+			`Current UV Index error: ${response.status} ${response.statusText}`,
+		);
+	}
+
+	return response.json();
+}
+
+async function fetchMetNoForecast(
+	latitude: number,
+	longitude: number,
+): Promise<MetNoResponse> {
+	const url = new URL(MET_NO_FORECAST_URL);
+	url.search = new URLSearchParams({
+		lat: latitude.toString(),
+		lon: longitude.toString(),
+	}).toString();
+
+	const response = await fetchWithTimeout(url, {
+		headers: {
+			Accept: "application/json",
+			"User-Agent": "SunburnTimer/1.0 https://github.com/coloboxp/sunburntimer",
+		},
+	});
+	if (!response.ok) {
+		throw new Error(
+			`MET Norway error: ${response.status} ${response.statusText}`,
+		);
+	}
+
+	return response.json();
+}
+
+function normalizeOpenMeteoWeatherData(
+	data: OpenMeteoResponse,
+	aqi: OpenMeteoAqiResponse | undefined,
+): WeatherData {
+	if (!data.current || !data.hourly || !data.daily) {
+		throw new Error("Invalid weather data received from Open-Meteo");
+	}
+
+	const timezone = data.timezone;
+	if (!timezone) {
+		throw new Error("Missing weather timezone");
+	}
+
+	const currentTime = data.current.time;
+	const currentTemp = data.current.temperature_2m;
+	const currentUvi = data.current.uv_index;
+	const currentWeatherCode = data.current.weather_code;
+	if (
+		!currentTime ||
+		typeof currentTemp !== "number" ||
+		typeof currentUvi !== "number" ||
+		typeof currentWeatherCode !== "number"
+	) {
+		throw new Error("Missing current Open-Meteo weather fields");
+	}
+
+	const hourlyTime = data.hourly.time ?? [];
+	const hourlyTemp = data.hourly.temperature_2m ?? [];
+	const hourlyUvi = data.hourly.uv_index ?? [];
+	const hourlyWeatherCode = data.hourly.weather_code ?? [];
+	const hourly = hourlyTime.flatMap((time, index) => {
+		const temp = hourlyTemp[index];
+		const uvi = hourlyUvi[index];
+		const weatherCode = hourlyWeatherCode[index];
+		if (
+			typeof temp !== "number" ||
+			typeof uvi !== "number" ||
+			typeof weatherCode !== "number"
+		) {
+			return [];
+		}
+
+		return [
+			{
+				dt: Math.floor(parseLocationTime(time, timezone) / 1000),
+				temp,
+				uvi,
+				weather: [normalizeWeatherOverview(weatherCode)],
+			},
+		];
+	});
+
+	const sunrise = data.daily.sunrise?.[0];
+	const sunset = data.daily.sunset?.[0];
+	const nextSunrise = data.daily.sunrise?.[1];
+	if (!sunrise || !sunset || !nextSunrise) {
+		throw new Error("Missing sunrise or sunset metadata");
+	}
+
+	return {
+		provider: "open-meteo",
+		current: {
+			dt: Math.floor(parseLocationTime(currentTime, timezone) / 1000),
+			temp: currentTemp,
+			uvi: currentUvi,
+			weather: [normalizeWeatherOverview(currentWeatherCode)],
+		},
+		hourly,
+		elevation: data.elevation,
+		aqi:
+			typeof aqi?.current?.us_aqi === "number"
+				? { us_aqi: Math.round(aqi.current.us_aqi) }
+				: undefined,
+		sunrise: new Date(parseLocationTime(sunrise, timezone)).toISOString(),
+		sunset: new Date(parseLocationTime(sunset, timezone)).toISOString(),
+		nextSunrise: new Date(
+			parseLocationTime(nextSunrise, timezone),
+		).toISOString(),
+		timezone,
+	};
+}
+
+function normalizeUvFallbackWeatherData(
+	uvIndex: CurrentUvIndexResponse,
+	metNo: MetNoResponse,
+	timezone: string,
+): WeatherData {
+	if (uvIndex.ok !== true) {
+		const message = "message" in uvIndex ? uvIndex.message : undefined;
+		throw new Error(message || "Invalid Current UV Index response");
+	}
+
+	const uvPoints = [uvIndex.now, ...uvIndex.forecast].filter((point) =>
+		isValidUvPoint(point),
+	);
+	if (uvPoints.length === 0) {
+		throw new Error("Current UV Index did not return forecast points");
+	}
+
+	const metNoPoints = normalizeMetNoPoints(metNo);
+	if (metNoPoints.length === 0) {
+		throw new Error("MET Norway did not return temperature forecast points");
+	}
+
+	const currentTimeMs = Date.parse(uvIndex.now.time);
+	const currentMetNo = findNearestMetNoPoint(metNoPoints, currentTimeMs);
+	const hourly = uvPoints.slice(0, 120).map((point) => {
+		const timeMs = Date.parse(point.time);
+		const metNoPoint = findNearestMetNoPoint(metNoPoints, timeMs);
+
+		return {
+			dt: Math.floor(timeMs / 1000),
+			temp: metNoPoint.temp,
+			uvi: point.uvi,
+			weather: [normalizeMetNoWeatherOverview(metNoPoint.symbolCode)],
+		};
+	});
+	const sunTimes = buildSunTimes(
+		[...(uvIndex.history ?? []), ...uvPoints],
+		timezone,
+		currentTimeMs,
+	);
+
+	return {
+		provider: "current-uv-index",
+		current: {
+			dt: Math.floor(currentTimeMs / 1000),
+			temp: currentMetNo.temp,
+			uvi: uvIndex.now.uvi,
+			weather: [normalizeMetNoWeatherOverview(currentMetNo.symbolCode)],
+		},
+		hourly,
+		elevation: metNo.geometry?.coordinates?.[2] ?? 0,
+		sunrise: new Date(sunTimes.sunrise).toISOString(),
+		sunset: new Date(sunTimes.sunset).toISOString(),
+		nextSunrise: new Date(sunTimes.nextSunrise).toISOString(),
+		timezone,
+	};
+}
+
+function isValidUvPoint(point: CurrentUvIndexPoint): boolean {
+	return Number.isFinite(Date.parse(point.time)) && Number.isFinite(point.uvi);
+}
+
+function normalizeMetNoPoints(metNo: MetNoResponse): MetNoPoint[] {
+	return (metNo.properties?.timeseries ?? []).flatMap((entry) => {
+		const timeMs = entry.time ? Date.parse(entry.time) : Number.NaN;
+		const tempC = entry.data?.instant?.details?.air_temperature;
+		if (!Number.isFinite(timeMs) || typeof tempC !== "number") {
+			return [];
+		}
+
+		return [
+			{
+				timeMs,
+				temp: celsiusToFahrenheit(tempC),
+				symbolCode:
+					entry.data?.next_1_hours?.summary?.symbol_code ??
+					entry.data?.next_6_hours?.summary?.symbol_code ??
+					entry.data?.next_12_hours?.summary?.symbol_code,
+			},
+		];
+	});
+}
+
+function findNearestMetNoPoint(
+	points: MetNoPoint[],
+	timeMs: number,
+): MetNoPoint {
+	return points.reduce((nearest, point) => {
+		const nearestDistance = Math.abs(nearest.timeMs - timeMs);
+		const pointDistance = Math.abs(point.timeMs - timeMs);
+		return pointDistance < nearestDistance ? point : nearest;
+	});
+}
+
+function buildSunTimes(
+	uvPoints: CurrentUvIndexPoint[],
+	timezone: string,
+	currentTimeMs: number,
+): { sunrise: number; sunset: number; nextSunrise: number } {
+	const todayStart = getLocalDayStart(currentTimeMs, timezone);
+	const tomorrowStart = todayStart + DAY_MS;
+	const dayAfterTomorrowStart = tomorrowStart + DAY_MS;
+	const todayRange = getPositiveUvRange(uvPoints, todayStart, tomorrowStart);
+	const tomorrowRange = getPositiveUvRange(
+		uvPoints,
+		tomorrowStart,
+		dayAfterTomorrowStart,
+	);
+
+	return {
+		sunrise: todayRange ? todayRange.first - HOUR_MS : todayStart + 6 * HOUR_MS,
+		sunset: todayRange ? todayRange.last + HOUR_MS : todayStart + 18 * HOUR_MS,
+		nextSunrise: tomorrowRange
+			? tomorrowRange.first - HOUR_MS
+			: tomorrowStart + 6 * HOUR_MS,
+	};
+}
+
+function getLocalDayStart(timeMs: number, timezone: string): number {
+	const localTime = new TZDate(timeMs, timezone);
+	return new TZDate(
+		localTime.getFullYear(),
+		localTime.getMonth(),
+		localTime.getDate(),
+		0,
+		0,
+		0,
+		timezone,
+	).getTime();
+}
+
+function getPositiveUvRange(
+	uvPoints: CurrentUvIndexPoint[],
+	startMs: number,
+	endMs: number,
+): { first: number; last: number } | undefined {
+	const positiveTimes = uvPoints
+		.map((point) => ({ timeMs: Date.parse(point.time), uvi: point.uvi }))
+		.filter(
+			(point) =>
+				Number.isFinite(point.timeMs) &&
+				point.timeMs >= startMs &&
+				point.timeMs < endMs &&
+				point.uvi > 0.1,
+		)
+		.map((point) => point.timeMs)
+		.sort((a, b) => a - b);
+
+	const first = positiveTimes[0];
+	const last = positiveTimes[positiveTimes.length - 1];
+	if (first === undefined || last === undefined) {
+		return undefined;
+	}
+
+	return { first, last };
+}
+
+function celsiusToFahrenheit(celsius: number): number {
+	return (celsius * 9) / 5 + 32;
+}
+
+function parseLocationTime(timeStr: string, timezone: string): number {
+	const [datePart, timePart] = timeStr.split("T");
+	const [year, month, day] = datePart.split("-").map(Number);
+	const [hour, minute] = (timePart ?? "00:00").split(":").map(Number);
+
+	return new TZDate(year, month - 1, day, hour, minute, 0, timezone).getTime();
+}
+
+function normalizeWeatherOverview(weatherCode: number): WeatherOverview {
+	const description =
+		WMO_DESCRIPTIONS[weatherCode.toString() as keyof typeof WMO_DESCRIPTIONS] ??
+		"Unknown";
+
+	return {
+		id: 800,
+		main: description,
+		description,
+		icon: "01d",
+	};
+}
+
+function normalizeMetNoWeatherOverview(symbolCode: string | undefined) {
+	const description = toTitleCase(
+		(symbolCode || "weather")
+			.replaceAll("_", " ")
+			.replaceAll("clearsky", "clear sky")
+			.replaceAll("partlycloudy", "partly cloudy")
+			.replaceAll("lightrain", "light rain")
+			.replaceAll("fair", "fair")
+			.replace(/\b(day|night|polartwilight)\b/g, "")
+			.trim(),
+	);
+
+	return {
+		id: 800,
+		main: description || "Weather",
+		description: description || "Weather",
+		icon: symbolCode || "",
+	};
+}
+
+function toTitleCase(value: string): string {
+	return value.replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+function weatherResponse(body: WeatherData): Response {
+	return jsonResponse(body, 200, {
+		"Cache-Control": "no-store",
+		"X-Weather-Provider": body.provider,
+	});
+}
+
+function jsonResponse(
+	body: unknown,
+	status: number,
+	headers?: Record<string, string>,
+): Response {
+	return Response.json(body, {
+		status,
+		headers: {
+			...headers,
+			"Content-Type": "application/json",
+		},
+	});
+}

--- a/index.html
+++ b/index.html
@@ -3,10 +3,9 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <link rel="alternate icon" href="/favicon.ico" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="description" content="Free sunburn calculator shows how long until you burn based on UV index, skin type, and SPF. Get personalized sun exposure times and UV burn time estimates." />
+    <meta name="description" content="Free sunburn calculator estimates UV exposure by start time, skin type, SPF, sweat, weather, and time outside. Plan ahead and compare protection options." />
 
     <!-- Preconnect to external APIs -->
     <link rel="preconnect" href="https://api.open-meteo.com" />
@@ -20,8 +19,8 @@
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://sunburntimer.com/" />
-    <meta property="og:title" content="SunburnTimer: Find your carefree time in the sun" />
-    <meta property="og:description" content="Calculate safe sun exposure based on your skin type, weather conditions, and protection level. Enjoy the sun worry-free with science-based recommendations." />
+    <meta property="og:title" content="SunburnTimer: Plan your time in the sun" />
+    <meta property="og:description" content="Estimate sunburn risk from UV Index, skin type, SPF, sweat, weather, and planned time outside." />
     <meta property="og:image" content="https://sunburntimer.com/ogimage.png" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="800" />
@@ -31,8 +30,8 @@
     <!-- Twitter -->
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:url" content="https://sunburntimer.com/" />
-    <meta name="twitter:title" content="SunburnTimer: Find your carefree time in the sun" />
-    <meta name="twitter:description" content="Calculate safe sun exposure based on your skin type, weather conditions, and protection level. Enjoy the sun worry-free with science-based recommendations." />
+    <meta name="twitter:title" content="SunburnTimer: Plan your time in the sun" />
+    <meta name="twitter:description" content="Estimate sunburn risk from UV Index, skin type, SPF, sweat, weather, and planned time outside." />
     <meta name="twitter:image" content="https://sunburntimer.com/ogimage.png" />
     <meta name="twitter:image:alt" content="SunburnTimer - Smart Sun Exposure Calculator" />
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,22 +1,30 @@
-import { useEffect } from "react";
-import { RefreshCw, Sun } from "lucide-react";
+import { useEffect, useMemo } from "react";
+import { RefreshCw } from "lucide-react";
 import { haptic } from "ios-haptics";
 import { useAppStore, useIsReadyToCalculate } from "./store";
-import { findOptimalTimeSlicing } from "./calculations";
+import { findOptimalTimeSlicing, recommendSPF } from "./calculations";
 import {
 	SPF_CONFIG,
 	SPFLevel,
 	SWEAT_CONFIG,
 	DEFAULT_SWEAT_LEVEL,
+	StartTimeMode,
 } from "./types";
 import { useLocationRefresh } from "./hooks/useLocationRefresh";
-import { fetchWeatherData } from "./services/weather";
+import { useCurrentTime } from "./hooks/useCurrentTime";
+import {
+	fetchWeatherData,
+	getActiveWeatherProvider,
+	isGoogleWeatherTestRoute,
+} from "./services/weather";
 import { getUVIndexColor, getAQIColor } from "./lib/utils";
+import { parseDateTimeLocal } from "./utils/timezone";
 
 import { SkinTypeSelector } from "./components/SkinTypeSelector";
 import { SPFSelector } from "./components/SPFSelector";
 import { SweatLevelSelector } from "./components/SweatLevelSelector";
 import { LocationSelector } from "./components/LocationSelector";
+import { PlanControls } from "./components/PlanControls";
 import { ResultsDisplay } from "./components/ResultsDisplay";
 import { BurnChart } from "./components/BurnChart";
 import { UVChart } from "./components/UVChart";
@@ -41,6 +49,11 @@ function App() {
 		skinType,
 		spfLevel,
 		sweatLevel,
+		startTimeMode,
+		plannedStartTime,
+		plannedDurationMinutes,
+		exposureGoal,
+		weatherProvider,
 		geolocation,
 		calculation,
 		setCalculation,
@@ -50,6 +63,7 @@ function App() {
 	} = useAppStore();
 
 	const isReadyToCalculate = useIsReadyToCalculate();
+	const currentTime = useCurrentTime();
 
 	// Check if user has pre-loaded preferences (returning user)
 	const hasPreloadedPrefs = !!(skinType && spfLevel);
@@ -57,29 +71,47 @@ function App() {
 	// Refresh weather data for saved locations
 	useLocationRefresh();
 
-	// Auto-calculate when all inputs are ready
-	useEffect(() => {
+	const calculationStartTime = useMemo(() => {
+		if (startTimeMode !== StartTimeMode.PLANNED || !plannedStartTime) {
+			return currentTime;
+		}
+
+		const parsedStartTime = parseDateTimeLocal(
+			plannedStartTime,
+			geolocation.weather?.timezone,
+		);
+
+		if (!parsedStartTime || parsedStartTime.getTime() < currentTime.getTime()) {
+			return currentTime;
+		}
+
+		return parsedStartTime;
+	}, [
+		startTimeMode,
+		plannedStartTime,
+		geolocation.weather?.timezone,
+		currentTime,
+	]);
+
+	const calculationInput = useMemo(() => {
 		if (
 			!isReadyToCalculate ||
 			!geolocation.weather ||
 			!geolocation.placeName ||
 			!skinType ||
-			!spfLevel
+			spfLevel === undefined
 		) {
-			return;
+			return undefined;
 		}
 
-		const input = {
+		return {
 			weather: geolocation.weather,
 			placeName: geolocation.placeName,
-			currentTime: new Date(),
+			currentTime: calculationStartTime,
 			skinType,
 			spfLevel,
 			sweatLevel: sweatLevel ?? DEFAULT_SWEAT_LEVEL,
 		};
-
-		const result = findOptimalTimeSlicing(input);
-		setCalculation(result);
 	}, [
 		isReadyToCalculate,
 		skinType,
@@ -87,8 +119,23 @@ function App() {
 		sweatLevel,
 		geolocation.weather,
 		geolocation.placeName,
-		setCalculation,
+		calculationStartTime,
 	]);
+
+	// Auto-calculate when all inputs are ready
+	useEffect(() => {
+		if (!calculationInput) {
+			return;
+		}
+
+		const result = findOptimalTimeSlicing(calculationInput);
+		setCalculation(result);
+	}, [calculationInput, setCalculation]);
+
+	const spfRecommendation = useMemo(() => {
+		if (!calculationInput) return undefined;
+		return recommendSPF(calculationInput, plannedDurationMinutes, exposureGoal);
+	}, [calculationInput, plannedDurationMinutes, exposureGoal]);
 
 	const handleRefresh = async () => {
 		if (!geolocation.position) return;
@@ -96,7 +143,14 @@ function App() {
 		try {
 			haptic();
 			setGeolocationStatus("fetching_weather");
-			const weather = await fetchWeatherData(geolocation.position);
+			const activeWeatherProvider =
+				isGoogleWeatherTestRoute() && weatherProvider
+					? weatherProvider
+					: getActiveWeatherProvider();
+			const weather = await fetchWeatherData(
+				geolocation.position,
+				activeWeatherProvider,
+			);
 			haptic.confirm();
 			setWeather(weather);
 		} catch (error) {
@@ -111,12 +165,17 @@ function App() {
 
 	return (
 		<div className="min-h-screen bg-orange-50">
-			<div className="container mx-auto px-4 py-8 max-w-4xl">
+			<div className="container mx-auto max-w-5xl px-4 py-5">
 				{/* Header */}
-				<div className="mb-8">
+				<div className="mb-5">
 					<div className="flex items-center mb-2">
-						<Sun className="w-8 h-8 text-amber-600 mr-4" />
-						<h1 className="text-3xl font-bold text-slate-800">
+						<img
+							src="/favicon.svg"
+							alt=""
+							aria-hidden="true"
+							className="mr-3 h-9 w-9"
+						/>
+						<h1 className="text-2xl font-bold text-slate-800">
 							Sunburn Calculator
 						</h1>
 					</div>
@@ -129,18 +188,26 @@ function App() {
 					</p>
 				</div>
 
+				<div className="mb-6">
+					<PlanControls
+						currentTime={currentTime}
+						timezone={geolocation.weather?.timezone}
+						recommendation={spfRecommendation}
+					/>
+				</div>
+
 				{/* Steps Accordion */}
 				<Accordion
 					type="multiple"
 					defaultValue={hasPreloadedPrefs ? [] : ["step1", "step2", "step3"]}
-					className="space-y-4"
+					className="space-y-3"
 				>
 					{/* Step 1: Skin Type */}
 					<AccordionItem
 						value="step1"
 						className="bg-card border-stone-200 shadow-sm rounded-lg mb-4"
 					>
-						<AccordionTrigger className="px-6 py-4 hover:no-underline">
+						<AccordionTrigger className="px-5 py-3 hover:no-underline">
 							<div className="flex-1 text-left">
 								<StepHeader
 									stepNumber={1}
@@ -156,7 +223,7 @@ function App() {
 								)}
 							</div>
 						</AccordionTrigger>
-						<AccordionContent className="px-6 pb-6">
+						<AccordionContent className="px-5 pb-5">
 							<SkinTypeSelector />
 						</AccordionContent>
 					</AccordionItem>
@@ -166,7 +233,7 @@ function App() {
 						value="step2"
 						className="bg-card border-stone-200 shadow-sm rounded-lg mb-4"
 					>
-						<AccordionTrigger className="px-6 py-4 hover:no-underline">
+						<AccordionTrigger className="px-5 py-3 hover:no-underline">
 							<div className="flex-1 text-left">
 								<StepHeader
 									stepNumber={2}
@@ -189,7 +256,7 @@ function App() {
 								)}
 							</div>
 						</AccordionTrigger>
-						<AccordionContent className="px-6 pb-6">
+						<AccordionContent className="px-5 pb-5">
 							<div className="space-y-6">
 								<SPFSelector />
 
@@ -210,7 +277,7 @@ function App() {
 						value="step3"
 						className="bg-card border-stone-200 shadow-sm rounded-lg mb-4"
 					>
-						<AccordionTrigger className="px-6 py-4 hover:no-underline">
+						<AccordionTrigger className="px-5 py-3 hover:no-underline">
 							<div className="flex-1 text-left">
 								<StepHeader
 									stepNumber={3}
@@ -258,7 +325,7 @@ function App() {
 									)}
 							</div>
 						</AccordionTrigger>
-						<AccordionContent className="px-6 pb-6">
+						<AccordionContent className="px-5 pb-5">
 							<LocationSelector />
 						</AccordionContent>
 					</AccordionItem>
@@ -266,9 +333,9 @@ function App() {
 
 				{/* Results */}
 				{calculation && (
-					<div className="mt-8 space-y-6">
+					<div className="mt-6 space-y-5">
 						<div className="flex items-center justify-between">
-							<h2 className="text-2xl font-bold text-slate-800">
+							<h2 className="text-xl font-bold text-slate-800">
 								Safe Sun Exposure Time
 							</h2>
 							<div className="flex space-x-2">
@@ -302,6 +369,8 @@ function App() {
 							<UVChart
 								result={calculation}
 								timezone={geolocation.weather?.timezone}
+								activityStartTime={calculationStartTime}
+								activityDurationMinutes={plannedDurationMinutes}
 							/>
 						</div>
 						<SunPositionCard />
@@ -328,6 +397,15 @@ function App() {
 							>
 								Jon Callahan
 							</a>
+							<span className="text-slate-400">+</span>
+							<a
+								href="https://github.com/coloboxp"
+								target="_blank"
+								rel="noopener noreferrer"
+								className="hover:text-amber-600 transition-colors"
+							>
+								@coloboxp additions
+							</a>
 						</div>
 						<div className="flex items-center gap-4">
 							<a
@@ -337,14 +415,6 @@ function App() {
 								className="hover:text-amber-600 transition-colors"
 							>
 								GitHub
-							</a>
-							<a
-								href="https://buymeacoffee.com/joncallahan"
-								target="_blank"
-								rel="noopener noreferrer"
-								className="bg-amber-100 text-amber-800 px-3 py-1 rounded-full hover:bg-amber-200 transition-colors"
-							>
-								☕ Buy me a coffee
 							</a>
 						</div>
 					</div>

--- a/src/calculations.test.ts
+++ b/src/calculations.test.ts
@@ -1,7 +1,13 @@
 import { describe, it, expect } from "bun:test";
-import { findOptimalTimeSlicing } from "./calculations";
+import {
+	calculateExposureDamage,
+	findOptimalTimeSlicing,
+	recommendSPF,
+	recoverSkinDamagePercent,
+	UVB_SKIN_RECOVERY,
+} from "./calculations";
 import type { CalculationInput, WeatherData, CalculationResult } from "./types";
-import { FitzpatrickType, SPFLevel, SweatLevel } from "./types";
+import { ExposureGoal, FitzpatrickType, SPFLevel, SweatLevel } from "./types";
 
 // Test helper functions
 function createMockWeatherData(
@@ -17,7 +23,7 @@ function createMockWeatherData(
 			feels_like: 75,
 			pressure: 1013,
 			humidity: 50,
-			uvi: uvValues[0] || 5,
+			uvi: uvValues[0] ?? 5,
 			clouds: 20,
 			wind_speed: 5,
 			weather: [
@@ -65,6 +71,29 @@ function createTestScenario(
 	};
 }
 
+function createObservedCurrentUvScenario(
+	forecastUvValues: number[],
+	currentObservedUvi: number,
+	currentTime: Date,
+): CalculationInput {
+	const hourStartSeconds = Math.floor(
+		new Date(currentTime).setMinutes(0, 0, 0) / 1000,
+	);
+	const weather = createMockWeatherData(forecastUvValues, hourStartSeconds);
+
+	weather.current.dt = Math.floor(currentTime.getTime() / 1000);
+	weather.current.uvi = currentObservedUvi;
+
+	return {
+		weather,
+		placeName: "Test Location",
+		currentTime,
+		skinType: FitzpatrickType.II,
+		spfLevel: SPFLevel.NONE,
+		sweatLevel: SweatLevel.LOW,
+	};
+}
+
 // Utility functions for test assertions
 function getBurnTimeMinutes(
 	result: CalculationResult,
@@ -80,6 +109,11 @@ function getBurnTimeHours(
 	input: CalculationInput,
 ): number {
 	return getBurnTimeMinutes(result, input) / 60;
+}
+
+function getPointEndDamage(result: CalculationResult, index: number): number {
+	const point = result.points[index];
+	return point ? point.totalDamageAtStart + point.burnCost : 0;
 }
 
 function expectRelativeBurnTime(
@@ -229,6 +263,60 @@ describe("Sunburn Calculation Algorithm", () => {
 		});
 	});
 
+	describe("Current UV Anchoring", () => {
+		it("uses the observed current UV for the first forecast segment when current UV is lower", () => {
+			const currentTime = new Date("2025-09-06T09:30:00");
+			const anchoredInput = createObservedCurrentUvScenario(
+				[8, 8, 8, 8],
+				2,
+				currentTime,
+			);
+			const forecastOnlyInput = createObservedCurrentUvScenario(
+				[8, 8, 8, 8],
+				8,
+				currentTime,
+			);
+
+			const anchoredResult = findOptimalTimeSlicing(anchoredInput);
+			const forecastOnlyResult = findOptimalTimeSlicing(forecastOnlyInput);
+
+			expect(anchoredResult.points[0]?.slice.uvIndex).toBeLessThan(4);
+			expectRelativeBurnTime(
+				forecastOnlyResult,
+				forecastOnlyInput,
+				anchoredResult,
+				anchoredInput,
+				"Lower observed current UV should extend the near-term burn estimate",
+			);
+		});
+
+		it("uses the observed current UV for the first forecast segment when current UV is higher", () => {
+			const currentTime = new Date("2025-09-06T09:30:00");
+			const anchoredInput = createObservedCurrentUvScenario(
+				[6, 6, 6, 6],
+				10,
+				currentTime,
+			);
+			const forecastOnlyInput = createObservedCurrentUvScenario(
+				[6, 6, 6, 6],
+				6,
+				currentTime,
+			);
+
+			const anchoredResult = findOptimalTimeSlicing(anchoredInput);
+			const forecastOnlyResult = findOptimalTimeSlicing(forecastOnlyInput);
+
+			expect(anchoredResult.points[0]?.slice.uvIndex).toBeGreaterThan(7);
+			expectRelativeBurnTime(
+				anchoredResult,
+				anchoredInput,
+				forecastOnlyResult,
+				forecastOnlyInput,
+				"Higher observed current UV should shorten the near-term burn estimate",
+			);
+		});
+	});
+
 	describe("SPF Protection Levels", () => {
 		it("should provide appropriate protection for SPF 15", () => {
 			const withoutSPF = createTestScenario(
@@ -359,6 +447,52 @@ describe("Sunburn Calculation Algorithm", () => {
 				typeVI.input,
 				"Type I should burn much faster than Type VI",
 			);
+		});
+	});
+
+	describe("Leaky Bucket Recovery", () => {
+		it("should recover accumulated UVB damage over the published recovery window", () => {
+			const startingDamage = 80;
+			const recoveredDamage = recoverSkinDamagePercent(
+				startingDamage,
+				UVB_SKIN_RECOVERY.recoveryPeriodHours * 60,
+			);
+
+			expect(recoveredDamage).toBeCloseTo(
+				startingDamage * UVB_SKIN_RECOVERY.remainingFractionAfterRecoveryPeriod,
+				6,
+			);
+		});
+
+		it("should leak accumulated damage during a no-UV break before later exposure", () => {
+			const fixedTime = new Date("2025-09-06T08:00:00-06:00");
+			const input = createTestScenario(
+				FitzpatrickType.VI,
+				SPFLevel.NONE,
+				SweatLevel.LOW,
+				[6, 6, 0, 0, 0, 0, 6, 6],
+				fixedTime,
+			);
+
+			const result = findOptimalTimeSlicing(input);
+			const morningCutoffMs = fixedTime.getTime() + 2.5 * 60 * 60 * 1000;
+			const afternoonRestartMs = fixedTime.getTime() + 5.5 * 60 * 60 * 1000;
+			const morningPeakDamage = Math.max(
+				...result.points
+					.map((point, index) => ({
+						time: point.slice.datetime.getTime(),
+						damage: getPointEndDamage(result, index),
+					}))
+					.filter((point) => point.time <= morningCutoffMs)
+					.map((point) => point.damage),
+			);
+			const damageBeforeAfternoon = result.points.find(
+				(point) => point.slice.datetime.getTime() >= afternoonRestartMs,
+			)?.totalDamageAtStart;
+
+			expect(morningPeakDamage).toBeGreaterThan(30);
+			expect(damageBeforeAfternoon).toBeDefined();
+			expect(damageBeforeAfternoon ?? 0).toBeLessThan(morningPeakDamage * 0.8);
 		});
 	});
 
@@ -604,6 +738,62 @@ describe("Sunburn Calculation Algorithm", () => {
 			if (lowSweatTime !== Infinity && highSweatTime !== Infinity) {
 				expect(highSweatTime).toBeLessThanOrEqual(lowSweatTime);
 			}
+		});
+	});
+
+	describe("Exposure Planning", () => {
+		it("should estimate lower planned dose with stronger SPF", () => {
+			const fixedTime = new Date("2025-09-06T09:00:00");
+			const noSpf = createTestScenario(
+				FitzpatrickType.II,
+				SPFLevel.NONE,
+				SweatLevel.LOW,
+				Array(4).fill(8),
+				fixedTime,
+			);
+			const spf30 = {
+				...noSpf,
+				spfLevel: SPFLevel.SPF_30,
+			};
+
+			const noSpfDamage = calculateExposureDamage(noSpf, 60);
+			const spf30Damage = calculateExposureDamage(spf30, 60);
+
+			expect(noSpfDamage.forecastComplete).toBe(true);
+			expect(spf30Damage.forecastComplete).toBe(true);
+			expect(spf30Damage.damage).toBeLessThan(noSpfDamage.damage);
+		});
+
+		it("should recommend high SPF when the goal is no visible change", () => {
+			const fixedTime = new Date("2025-09-06T09:00:00");
+			const input = createTestScenario(
+				FitzpatrickType.II,
+				SPFLevel.NONE,
+				SweatLevel.LOW,
+				Array(4).fill(8),
+				fixedTime,
+			);
+
+			const recommendation = recommendSPF(input, 60, ExposureGoal.AVOID_CHANGE);
+
+			expect(recommendation.level).toBe(SPFLevel.SPF_50_PLUS);
+			expect(recommendation.status).toBe("fits_goal");
+		});
+
+		it("should recommend a lower SPF when the user accepts light color", () => {
+			const fixedTime = new Date("2025-09-06T09:00:00");
+			const input = createTestScenario(
+				FitzpatrickType.II,
+				SPFLevel.NONE,
+				SweatLevel.LOW,
+				Array(4).fill(8),
+				fixedTime,
+			);
+
+			const recommendation = recommendSPF(input, 120, ExposureGoal.LIGHT_COLOR);
+
+			expect(recommendation.level).toBe(SPFLevel.SPF_15);
+			expect(recommendation.status).toBe("fits_goal");
 		});
 	});
 });

--- a/src/calculations.ts
+++ b/src/calculations.ts
@@ -2,17 +2,22 @@ import type {
 	CalculationInput,
 	CalculationResult,
 	CalculationPoint,
+	ExposureDamageEstimate,
 	TimeSlice,
-	HourlyWeather,
 	FitzpatrickType,
+	SPFRecommendation,
+	SPFRecommendationOption,
+	ExposureGoal as ExposureGoalType,
 } from "./types";
 import {
 	SweatLevel,
 	SPFLevel,
+	ExposureGoal,
 	CALCULATION_CONSTANTS,
 	SKIN_TYPE_CONFIG,
 	SPF_CONFIG,
 	SWEAT_CONFIG,
+	EXPOSURE_GOAL_CONFIG,
 } from "./types";
 import { getHoursInTimezone } from "./utils/timezone";
 
@@ -24,11 +29,80 @@ import { getHoursInTimezone } from "./utils/timezone";
 // It converts UV Index to skin-damaging energy, adjusts for sunscreen and skin sensitivity, and adds up damage percentages.**
 const UVI_DAMAGE_FACTOR_PER_MIN = 120;
 
+export const UVB_SKIN_RECOVERY = {
+	// Arbabi, Gange & Parrish measured normal-skin UVB recovery at 24-30h.
+	// This model uses the midpoint and treats "recovered" as 95% drained.
+	recoveryPeriodHours: 27,
+	remainingFractionAfterRecoveryPeriod: 0.05,
+} as const;
+
+const SKIN_DAMAGE_RECOVERY_RATE_PER_MIN =
+	-Math.log(UVB_SKIN_RECOVERY.remainingFractionAfterRecoveryPeriod) /
+	(UVB_SKIN_RECOVERY.recoveryPeriodHours * 60);
+
 // **Derive MED (J/m²) from your existing coefficients:
 // (your config's comments match MED = 80 * coefficient)
 // MED is the 'Minimal Erythemal Dose'—the UV energy threshold for skin to start reddening. Lower for fair skin.**
 function getMedInJm2(skinType: FitzpatrickType): number {
 	return 80 * SKIN_TYPE_CONFIG[skinType].coefficient;
+}
+
+export function recoverSkinDamagePercent(
+	damagePercent: number,
+	elapsedMinutes: number,
+): number {
+	if (damagePercent <= 0) return 0;
+	if (elapsedMinutes <= 0) return damagePercent;
+	return (
+		damagePercent *
+		Math.exp(-SKIN_DAMAGE_RECOVERY_RATE_PER_MIN * elapsedMinutes)
+	);
+}
+
+function applyLeakyBucketRecovery(
+	damageAtStart: number,
+	damageRatePerMinute: number,
+	minutes: number,
+): number {
+	const clampedDamageAtStart = Math.max(0, damageAtStart);
+	const clampedDamageRate = Math.max(0, damageRatePerMinute);
+	if (minutes <= 0) return clampedDamageAtStart;
+	if (clampedDamageRate === 0) {
+		return recoverSkinDamagePercent(clampedDamageAtStart, minutes);
+	}
+
+	const steadyStateDamage =
+		clampedDamageRate / SKIN_DAMAGE_RECOVERY_RATE_PER_MIN;
+	const decay = Math.exp(-SKIN_DAMAGE_RECOVERY_RATE_PER_MIN * minutes);
+	return Math.max(
+		0,
+		steadyStateDamage + (clampedDamageAtStart - steadyStateDamage) * decay,
+	);
+}
+
+function getMinutesToDamageThreshold(
+	damageAtStart: number,
+	damageRatePerMinute: number,
+	threshold: number,
+	maxMinutes: number,
+): number | undefined {
+	if (damageAtStart >= threshold) return 0;
+	if (damageRatePerMinute <= 0 || maxMinutes <= 0) return undefined;
+
+	const steadyStateDamage =
+		damageRatePerMinute / SKIN_DAMAGE_RECOVERY_RATE_PER_MIN;
+	if (steadyStateDamage <= threshold) return undefined;
+
+	const ratio =
+		(threshold - steadyStateDamage) / (damageAtStart - steadyStateDamage);
+	if (ratio <= 0 || ratio >= 1) return undefined;
+
+	const minutesToThreshold =
+		-Math.log(ratio) / SKIN_DAMAGE_RECOVERY_RATE_PER_MIN;
+	if (minutesToThreshold < 0 || minutesToThreshold > maxMinutes) {
+		return undefined;
+	}
+	return minutesToThreshold;
 }
 
 // **Effective SPF at time offset (hours since application)
@@ -74,38 +148,135 @@ type SliceWindow = {
 	uviEnd: number;
 };
 
+function interpolateUvi(
+	startUvi: number,
+	endUvi: number,
+	fraction: number,
+): number {
+	return startUvi * (1 - fraction) + endUvi * fraction;
+}
+
 // **Build fixed sub-hour slices, keeping start & end UV for trapezoid integration
 // Breaks hourly UV data into smaller windows (e.g., 10-min) with interpolated UV at start/end.
 // This allows averaging UV changes smoothly, like connecting dots on a graph.**
 function createSlices(
-	hourly: HourlyWeather[],
+	input: CalculationInput,
 	slicesPerHour: number,
 ): SliceWindow[] {
 	const sliceWindows: SliceWindow[] = [];
+	const { hourly, current } = input.weather;
 	if (!hourly || hourly.length < 2) return sliceWindows;
 	const sliceMinutes = 60 / slicesPerHour;
+	const sliceDurationMs = sliceMinutes * 60000;
+	const currentObservationMs = current.dt * 1000;
+
 	for (let i = 0; i < hourly.length - 1; i++) {
 		const currentHourWeather = hourly[i];
 		const nextHourWeather = hourly[i + 1];
 		const baseTimestampMs = currentHourWeather.dt * 1000;
-		for (let j = 0; j < slicesPerHour; j++) {
-			const sliceStartMs = baseTimestampMs + j * sliceMinutes * 60000;
-			const sliceEndMs = baseTimestampMs + (j + 1) * sliceMinutes * 60000;
-			const interpFractionStart = j / slicesPerHour;
-			const interpFractionEnd = (j + 1) / slicesPerHour;
+		const nextTimestampMs = nextHourWeather.dt * 1000;
+		let anchorStartMs = baseTimestampMs;
+		let anchorStartUvi = currentHourWeather.uvi;
+
+		if (
+			currentObservationMs >= baseTimestampMs &&
+			currentObservationMs < nextTimestampMs
+		) {
+			anchorStartMs = currentObservationMs;
+			anchorStartUvi = current.uvi;
+		}
+
+		const intervalDurationMs = nextTimestampMs - anchorStartMs;
+		if (intervalDurationMs <= 0) continue;
+
+		for (
+			let sliceStartMs = anchorStartMs;
+			sliceStartMs < nextTimestampMs;
+			sliceStartMs += sliceDurationMs
+		) {
+			const sliceEndMs = Math.min(
+				sliceStartMs + sliceDurationMs,
+				nextTimestampMs,
+			);
+			const interpFractionStart =
+				(sliceStartMs - anchorStartMs) / intervalDurationMs;
+			const interpFractionEnd =
+				(sliceEndMs - anchorStartMs) / intervalDurationMs;
+
 			sliceWindows.push({
 				start: new Date(sliceStartMs),
 				end: new Date(sliceEndMs),
-				uviStart:
-					currentHourWeather.uvi * (1 - interpFractionStart) +
-					nextHourWeather.uvi * interpFractionStart,
-				uviEnd:
-					currentHourWeather.uvi * (1 - interpFractionEnd) +
-					nextHourWeather.uvi * interpFractionEnd,
+				uviStart: interpolateUvi(
+					anchorStartUvi,
+					nextHourWeather.uvi,
+					interpFractionStart,
+				),
+				uviEnd: interpolateUvi(
+					anchorStartUvi,
+					nextHourWeather.uvi,
+					interpFractionEnd,
+				),
 			});
 		}
 	}
 	return sliceWindows;
+}
+
+function calculateSliceDamage(
+	input: CalculationInput,
+	currentSlice: SliceWindow,
+	effectiveStartMs: number,
+	effectiveEndMs: number,
+	startTimestampMs: number,
+	medInJm2: number,
+	baseSpfValue: number,
+): {
+	damageAddedInSlice: number;
+	damageRatePerMinute: number;
+	uviAtEffectiveStart: number;
+	uviAtEnd: number;
+} {
+	const minutes = (effectiveEndMs - effectiveStartMs) / 60000;
+	const sliceDurationMs =
+		currentSlice.end.getTime() - currentSlice.start.getTime();
+	const startFraction =
+		sliceDurationMs > 0
+			? (effectiveStartMs - currentSlice.start.getTime()) / sliceDurationMs
+			: 0;
+	const uviAtEffectiveStart =
+		currentSlice.uviStart * (1 - startFraction) +
+		currentSlice.uviEnd * startFraction;
+	const uviAtEnd = currentSlice.uviEnd;
+	const hoursFromStartAtEffective =
+		(effectiveStartMs - startTimestampMs) / 3600000;
+	const hoursFromStartAtEnd = (effectiveEndMs - startTimestampMs) / 3600000;
+	const spfAtEffectiveStart = spfAtTime(
+		baseSpfValue,
+		input.sweatLevel,
+		hoursFromStartAtEffective,
+	);
+	const spfAtEnd = spfAtTime(
+		baseSpfValue,
+		input.sweatLevel,
+		hoursFromStartAtEnd,
+	);
+	const effectiveIrradianceStart =
+		(uviAtEffectiveStart / Math.max(1, spfAtEffectiveStart)) *
+		lowUvWeight(uviAtEffectiveStart);
+	const effectiveIrradianceEnd =
+		(uviAtEnd / Math.max(1, spfAtEnd)) * lowUvWeight(uviAtEnd);
+	const averageEffectiveIrradiance =
+		0.5 * (effectiveIrradianceStart + effectiveIrradianceEnd);
+	const damageRatePerMinute =
+		(UVI_DAMAGE_FACTOR_PER_MIN * averageEffectiveIrradiance) / medInJm2;
+	const damageAddedInSlice = damageRatePerMinute * minutes;
+
+	return {
+		damageAddedInSlice,
+		damageRatePerMinute,
+		uviAtEffectiveStart,
+		uviAtEnd,
+	};
 }
 
 // **Check stopping conditions
@@ -174,7 +345,7 @@ function calculateBurnTimeWithSlices(
 	input: CalculationInput,
 	slicesPerHour: number,
 ): CalculationResult {
-	const sliceWindows = createSlices(input.weather.hourly, slicesPerHour);
+	const sliceWindows = createSlices(input, slicesPerHour);
 	const medInJm2 = getMedInJm2(input.skinType);
 	const baseSpfValue =
 		SPF_CONFIG[input.spfLevel]?.coefficient ??
@@ -196,65 +367,43 @@ function calculateBurnTimeWithSlices(
 		const effectiveEndMs = currentSlice.end.getTime();
 		const minutes = (effectiveEndMs - effectiveStartMs) / 60000;
 		if (minutes <= 0) continue;
-		// UV at effective start (if starting mid-slice)
-		const sliceDurationMs =
-			currentSlice.end.getTime() - currentSlice.start.getTime();
-		const startFraction =
-			sliceDurationMs > 0
-				? (effectiveStartMs - currentSlice.start.getTime()) / sliceDurationMs
-				: 0;
-		const uviAtEffectiveStart =
-			currentSlice.uviStart * (1 - startFraction) +
-			currentSlice.uviEnd * startFraction;
-		const uviAtEnd = currentSlice.uviEnd;
-		// SPF at endpoints (hours since application)
-		const hoursFromStartAtEffective =
-			(effectiveStartMs - startTimestampMs) / 3600000;
-		const hoursFromStartAtEnd = (effectiveEndMs - startTimestampMs) / 3600000;
-		const spfAtEffectiveStart = spfAtTime(
+		const sliceDamage = calculateSliceDamage(
+			input,
+			currentSlice,
+			effectiveStartMs,
+			effectiveEndMs,
+			startTimestampMs,
+			medInJm2,
 			baseSpfValue,
-			input.sweatLevel,
-			hoursFromStartAtEffective,
 		);
-		const spfAtEnd = spfAtTime(
-			baseSpfValue,
-			input.sweatLevel,
-			hoursFromStartAtEnd,
+		const damageAtEndOfSlice = applyLeakyBucketRecovery(
+			totalDamage,
+			sliceDamage.damageRatePerMinute,
+			minutes,
 		);
-		// Trapezoid on effective irradiance (UVI/SPF)
-		// **Effective irradiance: UV strength divided by SPF, weighted for low UV. Average start/end for smooth integration.**
-		const effectiveIrradianceStart =
-			(uviAtEffectiveStart / Math.max(1, spfAtEffectiveStart)) *
-			lowUvWeight(uviAtEffectiveStart);
-		const effectiveIrradianceEnd =
-			(uviAtEnd / Math.max(1, spfAtEnd)) * lowUvWeight(uviAtEnd);
-		const averageEffectiveIrradiance =
-			0.5 * (effectiveIrradianceStart + effectiveIrradianceEnd);
-		// Damage% added in this (possibly partial) window
-		// **Core formula: Converts average effective UV to damage % based on time and skin's MED.**
-		let damageAddedInSlice =
-			(UVI_DAMAGE_FACTOR_PER_MIN * averageEffectiveIrradiance * minutes) /
-			medInJm2;
+		let netDamageChangeInSlice = damageAtEndOfSlice - totalDamage;
 		// For display, record midpoint UV
 		const displayTimeSlice: TimeSlice = {
 			datetime: new Date(effectiveStartMs),
-			uvIndex: 0.5 * (uviAtEffectiveStart + uviAtEnd),
+			uvIndex: 0.5 * (sliceDamage.uviAtEffectiveStart + sliceDamage.uviAtEnd),
 		};
-		// Crossing inside the window? Clamp and compute exact burnTime
-		// **If damage would exceed threshold mid-slice, calculate exact time to hit 100% (linear approximation).**
-		if (!burnTime && totalDamage + damageAddedInSlice >= threshold) {
-			const damageRatePerMinute = damageAddedInSlice / minutes; // approx uniform within window
-			const minutesToThreshold =
-				(threshold - totalDamage) / damageRatePerMinute;
-			damageAddedInSlice = threshold - totalDamage; // clamp to reach exactly 100%
+		// Crossing inside the window? Solve the leaky-bucket exponential.
+		const minutesToThreshold = getMinutesToDamageThreshold(
+			totalDamage,
+			sliceDamage.damageRatePerMinute,
+			threshold,
+			minutes,
+		);
+		if (!burnTime && minutesToThreshold !== undefined) {
+			netDamageChangeInSlice = threshold - totalDamage; // clamp to reach exactly 100%
 			burnTime = new Date(effectiveStartMs + minutesToThreshold * 60000);
 		}
 		points.push({
 			slice: displayTimeSlice,
-			burnCost: damageAddedInSlice,
+			burnCost: netDamageChangeInSlice,
 			totalDamageAtStart: totalDamage,
 		});
-		totalDamage += damageAddedInSlice;
+		totalDamage = Math.max(0, totalDamage + netDamageChangeInSlice);
 		pointCount++;
 		if (
 			burnTime ||
@@ -290,4 +439,141 @@ export function findOptimalTimeSlicing(
 		}
 	}
 	return calculateBurnTimeWithSlices(input, 4);
+}
+
+export function calculateExposureDamage(
+	input: CalculationInput,
+	durationMinutes: number,
+	slicesPerHour = 30,
+): ExposureDamageEstimate {
+	const sliceWindows = createSlices(input, slicesPerHour);
+	const medInJm2 = getMedInJm2(input.skinType);
+	const baseSpfValue =
+		SPF_CONFIG[input.spfLevel]?.coefficient ??
+		SPF_CONFIG[SPFLevel.NONE].coefficient;
+	const startTimestampMs = input.currentTime.getTime();
+	const plannedEndMs = startTimestampMs + durationMinutes * 60000;
+	let totalDamage = 0;
+	let latestCoveredMs = startTimestampMs;
+
+	for (const currentSlice of sliceWindows) {
+		if (currentSlice.end.getTime() <= startTimestampMs) continue;
+		if (currentSlice.start.getTime() >= plannedEndMs) break;
+
+		const effectiveStartMs = Math.max(
+			currentSlice.start.getTime(),
+			startTimestampMs,
+		);
+		const effectiveEndMs = Math.min(currentSlice.end.getTime(), plannedEndMs);
+		if (effectiveEndMs <= effectiveStartMs) continue;
+
+		const sliceDamage = calculateSliceDamage(
+			input,
+			currentSlice,
+			effectiveStartMs,
+			effectiveEndMs,
+			startTimestampMs,
+			medInJm2,
+			baseSpfValue,
+		);
+		totalDamage = applyLeakyBucketRecovery(
+			totalDamage,
+			sliceDamage.damageRatePerMinute,
+			(effectiveEndMs - effectiveStartMs) / 60000,
+		);
+		latestCoveredMs = effectiveEndMs;
+	}
+
+	const coveredMinutes = Math.max(
+		0,
+		(latestCoveredMs - startTimestampMs) / 60000,
+	);
+
+	return {
+		damage: totalDamage,
+		coveredMinutes,
+		forecastComplete: coveredMinutes >= durationMinutes,
+	};
+}
+
+function getSpfRecommendationStatus(
+	goal: ExposureGoalType,
+	damage: number,
+): SPFRecommendation["status"] {
+	const goalConfig = EXPOSURE_GOAL_CONFIG[goal];
+	if (damage > goalConfig.maxDamage) return "too_risky";
+	if (damage < goalConfig.minDamage) return "below_goal";
+	return "fits_goal";
+}
+
+export function recommendSPF(
+	input: CalculationInput,
+	durationMinutes: number,
+	goal: ExposureGoalType,
+): SPFRecommendation {
+	const goalConfig = EXPOSURE_GOAL_CONFIG[goal];
+	const estimates = Object.values(SPFLevel).map((level) => ({
+		level,
+		estimate: calculateExposureDamage(
+			{
+				...input,
+				spfLevel: level,
+			},
+			durationMinutes,
+		),
+	}));
+	const options: SPFRecommendationOption[] = estimates.map(
+		({ level, estimate }) => ({
+			level,
+			damage: estimate.damage,
+		}),
+	);
+	const forecastComplete = estimates.every(
+		({ estimate }) => estimate.forecastComplete,
+	);
+
+	const exactMatches = options.filter(
+		(option) =>
+			option.damage >= goalConfig.minDamage &&
+			option.damage <= goalConfig.maxDamage,
+	);
+	const underMax = options.filter(
+		(option) => option.damage <= goalConfig.maxDamage,
+	);
+
+	let selected: SPFRecommendationOption;
+	if (goal === ExposureGoal.AVOID_CHANGE) {
+		selected = underMax.reduce(
+			(best, option) => (option.damage < best.damage ? option : best),
+			underMax[0] ?? options[options.length - 1],
+		);
+	} else if (exactMatches.length > 0) {
+		selected = exactMatches.reduce((best, option) =>
+			Math.abs(option.damage - goalConfig.targetDamage) <
+			Math.abs(best.damage - goalConfig.targetDamage)
+				? option
+				: best,
+		);
+	} else if (underMax.length > 0) {
+		selected = underMax.reduce((best, option) =>
+			Math.abs(option.damage - goalConfig.targetDamage) <
+			Math.abs(best.damage - goalConfig.targetDamage)
+				? option
+				: best,
+		);
+	} else {
+		selected = options.reduce((best, option) =>
+			option.damage < best.damage ? option : best,
+		);
+	}
+
+	return {
+		level: selected.level,
+		status: getSpfRecommendationStatus(goal, selected.damage),
+		damage: selected.damage,
+		goal,
+		durationMinutes,
+		options,
+		forecastComplete,
+	};
 }

--- a/src/components/BurnChart.tsx
+++ b/src/components/BurnChart.tsx
@@ -61,13 +61,9 @@ export function BurnChart({ result, timezone }: BurnChartProps) {
 
 	const chartData = useMemo(() => {
 		const times = filteredPoints.map((point) => point.slice.datetime);
-		const damageData = filteredPoints.map((_, i) => {
-			// Calculate cumulative damage up to this point
-			const cumulativeDamage = filteredPoints
-				.slice(0, i + 1)
-				.reduce((sum, point) => sum + point.burnCost, 0);
-			return Math.min(cumulativeDamage, 100);
-		});
+		const damageData = filteredPoints.map((point) =>
+			Math.max(0, Math.min(point.totalDamageAtStart + point.burnCost, 100)),
+		);
 
 		return {
 			labels: times,
@@ -127,7 +123,7 @@ export function BurnChart({ result, timezone }: BurnChartProps) {
 							return [
 								`Damage: ${damage}%`,
 								`UV Index: ${point.slice.uvIndex.toFixed(1)}`,
-								`Rate: ${point.burnCost.toFixed(2)}%/interval`,
+								`Net change: ${point.burnCost.toFixed(2)}%/interval`,
 							];
 						},
 					},
@@ -191,12 +187,9 @@ export function BurnChart({ result, timezone }: BurnChartProps) {
 	);
 
 	const burnTimeReached = useMemo(() => {
-		return filteredPoints.some((_, i) => {
-			const cumulativeDamage = filteredPoints
-				.slice(0, i + 1)
-				.reduce((sum, point) => sum + point.burnCost, 0);
-			return cumulativeDamage >= 100;
-		});
+		return filteredPoints.some(
+			(point) => point.totalDamageAtStart + point.burnCost >= 100,
+		);
 	}, [filteredPoints]);
 
 	return (
@@ -218,8 +211,8 @@ export function BurnChart({ result, timezone }: BurnChartProps) {
 
 				<div className="mt-4 text-sm text-muted-foreground">
 					<p>
-						This chart shows how skin damage accumulates over time based on UV
-						exposure, your skin type, and sun protection factors.
+						This chart shows estimated net skin damage over time based on UV
+						exposure, your skin type, sun protection, and slow UVB recovery.
 					</p>
 				</div>
 			</CardContent>

--- a/src/components/LocationSelector.tsx
+++ b/src/components/LocationSelector.tsx
@@ -1,3 +1,4 @@
+import { useId } from "react";
 import {
 	MapPin,
 	LoaderIcon,
@@ -8,26 +9,52 @@ import {
 } from "lucide-react";
 import { haptic } from "ios-haptics";
 import { useAppStore } from "../store";
+import { getCurrentPosition, reverseGeocode } from "../services/geolocation";
 import {
-	getCurrentPosition,
-	reverseGeocode,
-	formatElevation,
-} from "../services/geolocation";
-import { fetchWeatherData } from "../services/weather";
+	fetchWeatherData,
+	getActiveWeatherProvider,
+	getWeatherProviderLabel,
+	isGoogleWeatherTestRoute,
+} from "../services/weather";
+import { formatElevation, formatTemperature } from "../lib/units";
 import { LocationSearch } from "./LocationSearch";
 import type { GeocodingResult } from "../services/geocoding";
+import type { WeatherProvider } from "../types";
 import { Card, CardContent } from "./ui/card";
 import { Button } from "./ui/button";
 import { Alert, AlertDescription } from "./ui/alert";
+import { Label } from "./ui/label";
+import { RadioGroup, RadioGroupItem } from "./ui/radio-group";
 
 export function LocationSelector() {
+	const openMeteoProviderId = useId();
+	const googleProviderId = useId();
 	const {
 		geolocation,
+		unitSystem,
+		weatherProvider,
 		setGeolocationStatus,
 		setPosition,
 		setWeather,
 		setGeolocationError,
+		setWeatherProvider,
 	} = useAppStore();
+	const canChooseWeatherProvider = isGoogleWeatherTestRoute();
+	const activeWeatherProvider =
+		canChooseWeatherProvider && weatherProvider
+			? weatherProvider
+			: getActiveWeatherProvider();
+
+	const refreshWeatherForProvider = async (
+		provider: WeatherProvider,
+		position = geolocation.position,
+	) => {
+		if (!position) return;
+
+		setGeolocationStatus("fetching_weather");
+		const weather = await fetchWeatherData(position, provider);
+		setWeather(weather);
+	};
 
 	const handleSearchSelect = async (result: GeocodingResult) => {
 		try {
@@ -42,7 +69,7 @@ export function LocationSelector() {
 			setPosition(position, placeName, result.countryCode);
 
 			setGeolocationStatus("fetching_weather");
-			const weather = await fetchWeatherData(position);
+			const weather = await fetchWeatherData(position, activeWeatherProvider);
 			haptic.confirm();
 			setWeather(weather);
 		} catch (error) {
@@ -63,7 +90,7 @@ export function LocationSelector() {
 			setPosition(position, placeName, countryCode);
 
 			setGeolocationStatus("fetching_weather");
-			const weather = await fetchWeatherData(position);
+			const weather = await fetchWeatherData(position, activeWeatherProvider);
 			haptic.confirm();
 			setWeather(weather);
 		} catch (error) {
@@ -74,13 +101,27 @@ export function LocationSelector() {
 		}
 	};
 
+	const handleWeatherProviderChange = async (provider: WeatherProvider) => {
+		try {
+			haptic();
+			setWeatherProvider(provider);
+			await refreshWeatherForProvider(provider);
+			haptic.confirm();
+		} catch (error) {
+			haptic.error();
+			setGeolocationError(
+				error instanceof Error ? error.message : "Failed to fetch weather",
+			);
+		}
+	};
+
 	const renderStatus = () => {
 		switch (geolocation.status) {
 			case "blank":
 				return (
 					<Card>
-						<CardContent className="p-8 text-center">
-							<MapPin className="w-12 h-12 text-muted-foreground mx-auto mb-4" />
+						<CardContent className="p-4 text-center">
+							<MapPin className="mx-auto mb-2 h-7 w-7 text-muted-foreground" />
 							<p className="text-muted-foreground">
 								Choose your location to get weather data
 							</p>
@@ -189,10 +230,7 @@ export function LocationSelector() {
 								</span>
 								{geolocation.weather && (
 									<p className="text-sm text-green-700">
-										{formatElevation(
-											geolocation.weather.elevation,
-											geolocation.countryCode || "US",
-										)}{" "}
+										{formatElevation(geolocation.weather.elevation, unitSystem)}{" "}
 										elevation
 									</p>
 								)}
@@ -221,15 +259,26 @@ export function LocationSelector() {
 												<p className="text-sm text-muted-foreground">
 													Current Weather
 												</p>
+												<p className="text-xs text-muted-foreground">
+													{getWeatherProviderLabel(
+														geolocation.weather.provider,
+													)}
+												</p>
 												<p className="text-sm tabular-nums text-muted-foreground">
-													{Math.round(geolocation.weather.current.temp)}°F, UV
-													Index: {geolocation.weather.current.uvi}
+													{formatTemperature(
+														geolocation.weather.current.temp,
+														unitSystem,
+													)}
+													, UV Index: {geolocation.weather.current.uvi}
 												</p>
 											</div>
 										</div>
 										<div className="text-right">
 											<p className="text-2xl font-bold tabular-nums">
-												{Math.round(geolocation.weather.current.temp)}°
+												{formatTemperature(
+													geolocation.weather.current.temp,
+													unitSystem,
+												)}
 											</p>
 											<p className="text-sm text-muted-foreground capitalize">
 												{geolocation.weather.current.weather[0]?.description ||
@@ -267,12 +316,47 @@ export function LocationSelector() {
 
 	return (
 		<div className="space-y-6">
+			{canChooseWeatherProvider && (
+				<div className="space-y-3">
+					<Label className="text-sm font-medium text-slate-700">
+						Weather provider
+					</Label>
+					<RadioGroup
+						value={activeWeatherProvider}
+						onValueChange={(value) =>
+							handleWeatherProviderChange(value as WeatherProvider)
+						}
+						disabled={isLoading}
+						className="grid grid-cols-2 gap-2"
+					>
+						<Label
+							htmlFor={openMeteoProviderId}
+							className="flex cursor-pointer items-center gap-3 rounded-md border border-stone-200 bg-white px-3 py-2 text-sm text-slate-700 transition-colors has-[[data-state=checked]]:border-amber-500 has-[[data-state=checked]]:bg-amber-50 has-[[data-state=checked]]:text-amber-950"
+						>
+							<RadioGroupItem id={openMeteoProviderId} value="open-meteo" />
+							Open-Meteo
+						</Label>
+						<Label
+							htmlFor={googleProviderId}
+							className="flex cursor-pointer items-center gap-3 rounded-md border border-stone-200 bg-white px-3 py-2 text-sm text-slate-700 transition-colors has-[[data-state=checked]]:border-amber-500 has-[[data-state=checked]]:bg-amber-50 has-[[data-state=checked]]:text-amber-950"
+						>
+							<RadioGroupItem id={googleProviderId} value="google" />
+							Google
+						</Label>
+					</RadioGroup>
+					<p className="text-xs text-slate-500">
+						Google Weather is a preview path and needs `GOOGLE_MAPS_API_KEY` in
+						Vercel.
+					</p>
+				</div>
+			)}
+
 			<div className="grid grid-cols-1 gap-4">
 				<Button
 					variant="outline"
 					onClick={handleCurrentLocation}
 					disabled={isLoading}
-					className="h-auto p-4 border-dashed"
+					className="h-auto border-dashed p-3"
 				>
 					<MapPin className="w-5 h-5 mr-2" />
 					Use Current Location

--- a/src/components/LocationSelector.tsx
+++ b/src/components/LocationSelector.tsx
@@ -14,6 +14,7 @@ import {
 	fetchWeatherData,
 	getActiveWeatherProvider,
 	getWeatherProviderLabel,
+	getWeatherProviderUrl,
 	isGoogleWeatherTestRoute,
 } from "../services/weather";
 import { formatElevation, formatTemperature } from "../lib/units";
@@ -44,6 +45,9 @@ export function LocationSelector() {
 		canChooseWeatherProvider && weatherProvider
 			? weatherProvider
 			: getActiveWeatherProvider();
+	const weatherProviderUrl = getWeatherProviderUrl(
+		geolocation.weather?.provider,
+	);
 
 	const refreshWeatherForProvider = async (
 		provider: WeatherProvider,
@@ -259,11 +263,24 @@ export function LocationSelector() {
 												<p className="text-sm text-muted-foreground">
 													Current Weather
 												</p>
-												<p className="text-xs text-muted-foreground">
-													{getWeatherProviderLabel(
-														geolocation.weather.provider,
-													)}
-												</p>
+												{weatherProviderUrl ? (
+													<a
+														href={weatherProviderUrl}
+														target="_blank"
+														rel="noopener noreferrer"
+														className="text-xs text-muted-foreground underline-offset-2 hover:underline"
+													>
+														{getWeatherProviderLabel(
+															geolocation.weather.provider,
+														)}
+													</a>
+												) : (
+													<p className="text-xs text-muted-foreground">
+														{getWeatherProviderLabel(
+															geolocation.weather.provider,
+														)}
+													</p>
+												)}
 												<p className="text-sm tabular-nums text-muted-foreground">
 													{formatTemperature(
 														geolocation.weather.current.temp,

--- a/src/components/MathExplanation.tsx
+++ b/src/components/MathExplanation.tsx
@@ -100,20 +100,23 @@ export function MathExplanation() {
 								4. The calculation
 							</h3>
 							<p className="text-sm text-slate-600 mb-3">
-								Think of it as filling a bucket. Each minute adds UV damage, and
-								at 100% you're burnt.
+								Think of it as a leaky bucket. Each minute adds UV damage, while
+								normal skin recovery drains part of the accumulated dose.
 							</p>
 							<div className="bg-slate-900 text-slate-50 p-4 rounded-lg font-mono text-sm overflow-x-auto">
 								<div className="mb-2 text-slate-400">Each minute:</div>
-								<div>Damage % = (UV_Energy_Per_Min / (MED × SPF)) × 100</div>
+								<div>Net damage = UV dose added - recovery leak</div>
 							</div>
 							<p className="text-sm text-slate-600 mt-3">
 								This runs minute-by-minute using hourly UV forecasts,
-								interpolating between data points.
+								interpolating between data points and anchoring the first
+								segment to the observed current UV reading.
 							</p>
 							<p className="text-xs text-slate-500 mt-2">
-								For low UV (UVI &lt; 3), a smoothing curve accounts for reduced
-								effective exposure at dawn/dusk sun angles.
+								Recovery is modeled from UVB studies showing normal skin
+								recovers over roughly 24-30 hours. For low UV (UVI &lt; 3), a
+								smoothing curve accounts for reduced effective exposure at
+								dawn/dusk sun angles.
 							</p>
 						</div>
 
@@ -148,6 +151,16 @@ export function MathExplanation() {
 								<li className="text-slate-500">
 									McKinlay, A.F. & Diffey, B.L. (1987). "A reference action
 									spectrum for ultraviolet induced erythema in human skin."
+								</li>
+								<li>
+									<a
+										href="https://pubmed.ncbi.nlm.nih.gov/6863984/"
+										target="_blank"
+										rel="noopener noreferrer"
+										className="text-slate-600 hover:text-amber-600 hover:underline transition-colors"
+									>
+										Arbabi, Gange & Parrish: UVB recovery in normal skin
+									</a>
 								</li>
 								<li>
 									<a

--- a/src/components/PlanControls.tsx
+++ b/src/components/PlanControls.tsx
@@ -1,0 +1,352 @@
+import {
+	AlertTriangle,
+	Clock,
+	ExternalLink,
+	Ruler,
+	ShieldCheck,
+} from "lucide-react";
+import { useId, useMemo } from "react";
+import { useAppStore } from "../store";
+import {
+	ExposureGoal,
+	EXPOSURE_GOAL_CONFIG,
+	SPF_CONFIG,
+	StartTimeMode,
+	type SPFRecommendation,
+	UnitSystem,
+} from "../types";
+import { formatDateTimeLocal } from "../utils/timezone";
+import { Badge } from "./ui/badge";
+import { Button } from "./ui/button";
+import { Input } from "./ui/input";
+import { Label } from "./ui/label";
+
+interface PlanControlsProps {
+	currentTime: Date;
+	timezone?: string;
+	recommendation?: SPFRecommendation;
+}
+
+const FORECAST_WINDOW_DAYS = 3;
+const DURATION_PRESETS = [30, 60, 120, 240];
+const MIN_DURATION_MINUTES = 5;
+const MAX_DURATION_MINUTES = 720;
+
+function addHours(date: Date, hours: number): Date {
+	return new Date(date.getTime() + hours * 60 * 60 * 1000);
+}
+
+function addDays(date: Date, days: number): Date {
+	return new Date(date.getTime() + days * 24 * 60 * 60 * 1000);
+}
+
+function getDefaultPlannedStart(currentTime: Date, timezone?: string): string {
+	return formatDateTimeLocal(addHours(currentTime, 1), timezone);
+}
+
+function clampDuration(value: number): number {
+	if (!Number.isFinite(value)) return MIN_DURATION_MINUTES;
+	return Math.min(MAX_DURATION_MINUTES, Math.max(MIN_DURATION_MINUTES, value));
+}
+
+function formatPlannerDuration(minutes: number): string {
+	if (minutes < 60) return `${minutes}m`;
+	const hours = Math.floor(minutes / 60);
+	const remainingMinutes = minutes % 60;
+	return remainingMinutes === 0
+		? `${hours}h`
+		: `${hours}h ${remainingMinutes}m`;
+}
+
+function getRecommendationTone(status: SPFRecommendation["status"]): string {
+	switch (status) {
+		case "fits_goal":
+			return "border-green-200 bg-green-50 text-green-900";
+		case "below_goal":
+			return "border-sky-200 bg-sky-50 text-sky-900";
+		case "too_risky":
+			return "border-orange-200 bg-orange-50 text-orange-950";
+	}
+}
+
+function getRecommendationCopy(recommendation: SPFRecommendation): string {
+	switch (recommendation.status) {
+		case "fits_goal":
+			return "Fits your selected exposure goal.";
+		case "below_goal":
+			return "Lower than your color goal, but safer for your skin.";
+		case "too_risky":
+			return "Still above the selected goal. Shorten the plan, seek shade, or cover up.";
+	}
+}
+
+export function PlanControls({
+	currentTime,
+	timezone,
+	recommendation,
+}: PlanControlsProps) {
+	const plannedStartId = useId();
+	const plannedDurationId = useId();
+	const {
+		unitSystem,
+		startTimeMode,
+		plannedStartTime,
+		plannedDurationMinutes,
+		exposureGoal,
+		spfLevel,
+		setUnitSystem,
+		setStartTimeMode,
+		setPlannedStartTime,
+		setPlannedDurationMinutes,
+		setExposureGoal,
+		setSPFLevel,
+	} = useAppStore();
+
+	const defaultPlannedStart = useMemo(
+		() => getDefaultPlannedStart(currentTime, timezone),
+		[currentTime, timezone],
+	);
+	const plannedValue = plannedStartTime || defaultPlannedStart;
+	const minStart = useMemo(
+		() => formatDateTimeLocal(currentTime, timezone),
+		[currentTime, timezone],
+	);
+	const maxStart = useMemo(
+		() =>
+			formatDateTimeLocal(addDays(currentTime, FORECAST_WINDOW_DAYS), timezone),
+		[currentTime, timezone],
+	);
+
+	const selectPlannedStart = () => {
+		if (!plannedStartTime) {
+			setPlannedStartTime(defaultPlannedStart);
+		}
+		setStartTimeMode(StartTimeMode.PLANNED);
+	};
+
+	return (
+		<section className="rounded-lg border border-stone-200 bg-white/80 p-4 shadow-sm">
+			<div className="grid gap-4 lg:grid-cols-[1.3fr_0.9fr_0.8fr]">
+				<div className="space-y-3">
+					<Label htmlFor={plannedStartId}>
+						<Clock className="size-4 text-amber-600" />
+						Start
+					</Label>
+					<div className="grid gap-3 sm:grid-cols-[12rem_1fr]">
+						<div className="grid grid-cols-2 gap-1 rounded-md border border-stone-200 bg-stone-50 p-1">
+							<Button
+								type="button"
+								size="sm"
+								variant={
+									startTimeMode === StartTimeMode.NOW ? "default" : "ghost"
+								}
+								onClick={() => setStartTimeMode(StartTimeMode.NOW)}
+							>
+								Now
+							</Button>
+							<Button
+								type="button"
+								size="sm"
+								variant={
+									startTimeMode === StartTimeMode.PLANNED ? "default" : "ghost"
+								}
+								onClick={selectPlannedStart}
+							>
+								Later
+							</Button>
+						</div>
+						<Input
+							id={plannedStartId}
+							type="datetime-local"
+							value={plannedValue}
+							min={minStart}
+							max={maxStart}
+							disabled={startTimeMode === StartTimeMode.NOW}
+							onChange={(event) => {
+								setPlannedStartTime(event.target.value);
+								setStartTimeMode(StartTimeMode.PLANNED);
+							}}
+							className="tabular-nums"
+						/>
+					</div>
+				</div>
+
+				<div className="space-y-3">
+					<Label htmlFor={plannedDurationId}>Time outside</Label>
+					<div className="grid grid-cols-[1fr_6rem] gap-2">
+						<div className="grid grid-cols-4 gap-1 rounded-md border border-stone-200 bg-stone-50 p-1">
+							{DURATION_PRESETS.map((minutes) => (
+								<Button
+									key={minutes}
+									type="button"
+									size="sm"
+									variant={
+										plannedDurationMinutes === minutes ? "default" : "ghost"
+									}
+									onClick={() => setPlannedDurationMinutes(minutes)}
+								>
+									{formatPlannerDuration(minutes)}
+								</Button>
+							))}
+						</div>
+						<Input
+							id={plannedDurationId}
+							type="number"
+							min={MIN_DURATION_MINUTES}
+							max={MAX_DURATION_MINUTES}
+							step={5}
+							value={plannedDurationMinutes}
+							onChange={(event) =>
+								setPlannedDurationMinutes(
+									clampDuration(Number(event.target.value)),
+								)
+							}
+							className="tabular-nums"
+							aria-label="Minutes outside"
+						/>
+					</div>
+				</div>
+
+				<div className="space-y-3">
+					<Label>
+						<Ruler className="size-4 text-sky-700" />
+						Units
+					</Label>
+					<div className="grid grid-cols-2 gap-1 rounded-md border border-stone-200 bg-stone-50 p-1">
+						<Button
+							type="button"
+							size="sm"
+							variant={unitSystem === UnitSystem.IMPERIAL ? "default" : "ghost"}
+							onClick={() => setUnitSystem(UnitSystem.IMPERIAL)}
+						>
+							°F, mi
+						</Button>
+						<Button
+							type="button"
+							size="sm"
+							variant={unitSystem === UnitSystem.METRIC ? "default" : "ghost"}
+							onClick={() => setUnitSystem(UnitSystem.METRIC)}
+						>
+							°C, km
+						</Button>
+					</div>
+				</div>
+			</div>
+
+			<div className="mt-4 grid gap-4 lg:grid-cols-[1fr_1fr]">
+				<div className="space-y-3">
+					<Label>Goal</Label>
+					<div className="grid gap-1 rounded-md border border-stone-200 bg-stone-50 p-1 sm:grid-cols-3">
+						{Object.values(ExposureGoal).map((goal) => (
+							<Button
+								key={goal}
+								type="button"
+								size="sm"
+								variant={exposureGoal === goal ? "default" : "ghost"}
+								onClick={() => setExposureGoal(goal)}
+								className="h-auto min-h-8 whitespace-normal px-2 py-1"
+							>
+								{EXPOSURE_GOAL_CONFIG[goal].shortLabel}
+							</Button>
+						))}
+					</div>
+					<p className="text-xs leading-relaxed text-slate-600">
+						{EXPOSURE_GOAL_CONFIG[exposureGoal].description} A tan means UV
+						exposure, so this is a risk estimate, not a health promise.
+					</p>
+				</div>
+
+				<div
+					className={`rounded-lg border p-4 ${
+						recommendation
+							? getRecommendationTone(recommendation.status)
+							: "border-stone-200 bg-stone-50 text-slate-700"
+					}`}
+				>
+					<div className="flex items-start justify-between gap-3">
+						<div>
+							<div className="flex items-center gap-2 text-sm font-medium">
+								<ShieldCheck className="size-4" />
+								Recommended protection
+							</div>
+							{recommendation ? (
+								<>
+									<p className="mt-1 text-2xl font-bold tabular-nums">
+										{SPF_CONFIG[recommendation.level].label}
+									</p>
+									<p className="text-sm">
+										{getRecommendationCopy(recommendation)}
+									</p>
+									{spfLevel !== recommendation.level && (
+										<Button
+											type="button"
+											size="sm"
+											variant="outline"
+											className="mt-3 bg-white/70"
+											onClick={() => setSPFLevel(recommendation.level)}
+										>
+											Use {SPF_CONFIG[recommendation.level].label}
+										</Button>
+									)}
+								</>
+							) : (
+								<p className="mt-2 text-sm">
+									Choose skin type, location, and plan details to get an SPF
+									recommendation.
+								</p>
+							)}
+						</div>
+						{recommendation && (
+							<Badge variant="outline" className="bg-white/70 tabular-nums">
+								{Math.round(recommendation.damage)}% dose
+							</Badge>
+						)}
+					</div>
+
+					{recommendation && !recommendation.forecastComplete && (
+						<p className="mt-3 flex items-start gap-2 text-xs">
+							<AlertTriangle className="mt-0.5 size-3.5 shrink-0" />
+							The forecast does not cover the full plan.
+						</p>
+					)}
+
+					<div className="mt-3 border-t border-current/15 pt-3 text-xs leading-relaxed">
+						<p>
+							Based on UV Index, skin type, SPF, and sweat wear-off. Reapply
+							sunscreen at least every 2 hours and after sweating or swimming.
+						</p>
+						<div className="mt-2 flex flex-wrap gap-x-3 gap-y-1">
+							<a
+								href="https://www.cdc.gov/skin-cancer/sun-safety/"
+								target="_blank"
+								rel="noreferrer"
+								className="inline-flex items-center gap-1 underline underline-offset-2"
+							>
+								CDC
+								<ExternalLink className="size-3" />
+							</a>
+							<a
+								href="https://www.fda.gov/consumers/consumer-updates/tips-stay-safe-sun-sunscreen-sunglasses"
+								target="_blank"
+								rel="noreferrer"
+								className="inline-flex items-center gap-1 underline underline-offset-2"
+							>
+								FDA
+								<ExternalLink className="size-3" />
+							</a>
+							<a
+								href="https://www.aad.org/public/everyday-care/sun-protection/shade-clothing-sunscreen/how-to-select-sunscreen"
+								target="_blank"
+								rel="noreferrer"
+								className="inline-flex items-center gap-1 underline underline-offset-2"
+							>
+								AAD
+								<ExternalLink className="size-3" />
+							</a>
+						</div>
+					</div>
+				</div>
+			</div>
+		</section>
+	);
+}

--- a/src/components/ResultsDisplay.tsx
+++ b/src/components/ResultsDisplay.tsx
@@ -4,7 +4,7 @@ import { format } from "date-fns";
 import { Card, CardContent } from "./ui/card";
 import type { CalculationResult } from "../types";
 import { CALCULATION_CONSTANTS } from "../types";
-import { getHoursInTimezone } from "../utils/timezone";
+import { formatInTimeZone, getHoursInTimezone } from "../utils/timezone";
 import { formatDuration, calculateEnvironmentalTimes } from "../lib/utils";
 
 interface ResultsDisplayProps {
@@ -14,6 +14,11 @@ interface ResultsDisplayProps {
 
 export function ResultsDisplay({ result, timezone }: ResultsDisplayProps) {
 	const { burnTime, startTime, points, advice } = result;
+
+	const formatDisplayTime = (date: Date) =>
+		timezone
+			? formatInTimeZone(date, timezone, "h:mm a")
+			: format(date, "h:mm a");
 
 	const finalDamage = useMemo(() => {
 		if (points.length === 0) return 0;
@@ -25,9 +30,13 @@ export function ResultsDisplay({ result, timezone }: ResultsDisplayProps) {
 		if (!startTime || !burnTime) return null;
 
 		// Check if burn time is past midnight (next day)
-		const startDate = new Date(startTime);
-		const burnDate = new Date(burnTime);
-		const isNextDay = burnDate.getDate() !== startDate.getDate();
+		const startDate = timezone
+			? formatInTimeZone(startTime, timezone, "yyyy-MM-dd")
+			: format(startTime, "yyyy-MM-dd");
+		const burnDate = timezone
+			? formatInTimeZone(burnTime, timezone, "yyyy-MM-dd")
+			: format(burnTime, "yyyy-MM-dd");
+		const isNextDay = burnDate !== startDate;
 		const isPastMidnight = isNextDay;
 
 		if (isPastMidnight) {
@@ -36,7 +45,7 @@ export function ResultsDisplay({ result, timezone }: ResultsDisplayProps) {
 
 		const diffMs = burnTime.getTime() - startTime.getTime();
 		return formatDuration(diffMs);
-	}, [startTime, burnTime]);
+	}, [startTime, burnTime, timezone]);
 
 	const environmentalTimes = useMemo(() => {
 		if (!startTime || !burnTime || safeTime === "unlikely") return null;
@@ -90,8 +99,10 @@ export function ResultsDisplay({ result, timezone }: ResultsDisplayProps) {
 									</p>
 									<p className="text-slate-600 tabular-nums">
 										{isHighRisk
-											? `Use sunscreen by ${format(burnTime, "h:mm a")}, sun damage may occur after`
-											: `Until ${format(burnTime, "h:mm a")}`}
+											? `Burn risk around ${formatDisplayTime(burnTime)}`
+											: startTime
+												? `${formatDisplayTime(startTime)} to ${formatDisplayTime(burnTime)}`
+												: `Until ${formatDisplayTime(burnTime)}`}
 									</p>
 									{environmentalTimes && (
 										<p className="text-sm tabular-nums text-slate-500 mt-2">

--- a/src/components/SPFSelector.tsx
+++ b/src/components/SPFSelector.tsx
@@ -21,18 +21,18 @@ function SPFOption({ level, selected, onSelect }: SPFOptionProps) {
 			onClick={() => onSelect(level)}
 			aria-label={`Select ${config.label} sunscreen protection`}
 		>
-			<CardContent className="p-4">
+			<CardContent className="p-3">
 				<div className="flex items-center justify-between">
-					<div className="flex items-center space-x-4">
+					<div className="flex items-center gap-3">
 						<Badge
 							variant={selected ? "default" : "secondary"}
-							className="text-sm font-bold min-w-[2.5rem] justify-center"
+							className="min-w-[2.5rem] justify-center text-sm font-bold"
 						>
 							{level === SPFLevel.NONE ? "0" : config.label.replace("SPF ", "")}
 						</Badge>
 
 						<div className="text-left">
-							<div className="font-semibold">{config.label}</div>
+							<div className="text-sm font-semibold">{config.label}</div>
 						</div>
 					</div>
 
@@ -52,7 +52,7 @@ export function SPFSelector() {
 
 	return (
 		<div className="space-y-4">
-			<div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+			<div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
 				{Object.values(SPFLevel).map((level) => (
 					<SPFOption
 						key={level}

--- a/src/components/SkinTypeSelector.tsx
+++ b/src/components/SkinTypeSelector.tsx
@@ -1,5 +1,4 @@
 import { Check } from "lucide-react";
-import { useLayoutEffect, useRef, useMemo } from "react";
 import { FitzpatrickType, SKIN_TYPE_CONFIG } from "../types";
 import { useAppStore } from "../store";
 import { CardContent } from "./ui/card";
@@ -10,15 +9,9 @@ interface SkinTypeCardProps {
 	type: FitzpatrickType;
 	selected: boolean;
 	onSelect: (type: FitzpatrickType) => void;
-	cardRef?: React.RefObject<HTMLDivElement | null>;
 }
 
-function SkinTypeCard({
-	type,
-	selected,
-	onSelect,
-	cardRef,
-}: SkinTypeCardProps) {
+function SkinTypeCard({ type, selected, onSelect }: SkinTypeCardProps) {
 	const config = SKIN_TYPE_CONFIG[type];
 
 	// Use consistent dark text on white background
@@ -28,71 +21,70 @@ function SkinTypeCard({
 
 	return (
 		<SelectableCard
-			ref={cardRef}
 			selected={selected}
-			className="relative h-80 w-72 flex-shrink-0 snap-center overflow-hidden bg-white scroll-m-12"
+			className="relative min-h-36 overflow-hidden bg-white"
 			onClick={() => onSelect(type)}
 			aria-label={`Select skin type ${type}: ${config.subtitle}`}
 		>
 			{/* Skin tone stripe */}
 			<div
-				className="absolute left-0 top-0 bottom-0 w-6"
+				className="absolute left-0 top-0 bottom-0 w-2.5"
 				style={{ backgroundColor: config.color }}
 			/>
-			<CardContent className="p-4 pl-10 relative h-full flex flex-col">
-				<div className="flex-1 space-y-3">
+			<CardContent className="relative flex h-full flex-col p-3 pl-5">
+				<div className="flex-1 space-y-2">
 					{/* Header */}
 					<div className="flex items-start justify-between">
 						<div className="flex-1 min-w-0">
-							<div className="flex items-center space-x-2 mb-2">
-								<div className="text-3xl leading-none" aria-hidden="true">
+							<div className="flex items-center gap-1.5 mb-1">
+								<div className="text-2xl leading-none" aria-hidden="true">
 									{config.emoji}
 								</div>
 								<Badge
 									variant="secondary"
-									className="font-bold text-sm px-2 py-1 flex-shrink-0 bg-gray-100 text-gray-800"
+									className="flex-shrink-0 bg-gray-100 px-1.5 py-0.5 text-xs font-bold text-gray-800"
 								>
 									Type {type}
 								</Badge>
-								<div className={`font-bold text-base ${textColor} truncate`}>
+								<div className={`truncate text-sm font-bold ${textColor}`}>
 									{config.subtitle}
 								</div>
 							</div>
 						</div>
 
 						{selected && (
-							<div className="flex items-center justify-center w-6 h-6 bg-green-600 rounded-full shadow-lg flex-shrink-0 ml-2">
-								<Check className="w-4 h-4 text-white stroke-[3]" />
+							<div className="ml-1 flex h-5 w-5 flex-shrink-0 items-center justify-center rounded-full bg-green-600 shadow-lg">
+								<Check className="h-3.5 w-3.5 text-white stroke-[3]" />
 							</div>
 						)}
 					</div>
 
 					{/* Description */}
 					<div
-						className={`text-sm ${descriptionColor} font-medium leading-snug`}
+						className={`text-xs ${descriptionColor} font-medium leading-snug`}
 					>
 						{config.description}
 					</div>
 
 					{/* Attributes */}
-					<div className="space-y-2.5">
+					<div className="space-y-1.5">
 						<div>
 							<div className={`text-xs ${labelColor} mb-0.5`}>Hair</div>
-							<div className={`text-sm ${textColor} leading-snug`}>
+							<div className={`text-xs ${textColor} leading-snug`}>
 								{config.hairColors.join(", ")}
 							</div>
 						</div>
 
 						<div>
 							<div className={`text-xs ${labelColor} mb-0.5`}>Eyes</div>
-							<div className={`text-sm ${textColor} leading-snug`}>
+							<div className={`text-xs ${textColor} leading-snug`}>
 								{config.eyeColors.join(", ")}
 							</div>
 						</div>
 
 						<div>
 							<div className={`text-xs ${labelColor} mb-0.5`}>Freckles</div>
-							<div className={`text-sm ${textColor} leading-snug`}>
+							<div className={`text-xs ${textColor} leading-snug`}>
 								{config.freckles}
 							</div>
 						</div>
@@ -105,59 +97,18 @@ function SkinTypeCard({
 
 export function SkinTypeSelector() {
 	const { skinType, setSkinType } = useAppStore();
-	const containerRef = useRef<HTMLDivElement>(null);
-
-	// Create refs for each skin type - must be called outside of any loops
-	const typeIRef = useRef<HTMLDivElement>(null);
-	const typeIIRef = useRef<HTMLDivElement>(null);
-	const typeIIIRef = useRef<HTMLDivElement>(null);
-	const typeIVRef = useRef<HTMLDivElement>(null);
-	const typeVRef = useRef<HTMLDivElement>(null);
-	const typeVIRef = useRef<HTMLDivElement>(null);
-
-	const cardRefs = useMemo(
-		() => ({
-			[FitzpatrickType.I]: typeIRef,
-			[FitzpatrickType.II]: typeIIRef,
-			[FitzpatrickType.III]: typeIIIRef,
-			[FitzpatrickType.IV]: typeIVRef,
-			[FitzpatrickType.V]: typeVRef,
-			[FitzpatrickType.VI]: typeVIRef,
-		}),
-		[],
-	);
-
-	// Scroll selected card into view
-	useLayoutEffect(() => {
-		if (skinType && cardRefs[skinType]?.current) {
-			const selectedCard = cardRefs[skinType].current;
-
-			selectedCard.scrollIntoView({
-				behavior: "smooth",
-				block: "nearest",
-				inline: "center",
-			});
-		}
-	}, [skinType, cardRefs]);
 
 	return (
 		<div className="w-full">
-			<div
-				ref={containerRef}
-				className="flex overflow-x-auto gap-4 pb-4 snap-x snap-mandatory scrollbar-hide"
-			>
+			<div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
 				{Object.values(FitzpatrickType).map((type) => (
 					<SkinTypeCard
 						key={type}
 						type={type}
 						selected={skinType === type}
 						onSelect={setSkinType}
-						cardRef={cardRefs[type]}
 					/>
 				))}
-			</div>
-			<div className="text-center text-sm text-gray-500 mt-2">
-				Swipe to browse skin types
 			</div>
 		</div>
 	);

--- a/src/components/SunTimer.tsx
+++ b/src/components/SunTimer.tsx
@@ -37,33 +37,50 @@ export function SunTimer({ result }: SunTimerProps) {
 	// Calculate real-time damage based on elapsed time
 	const calculateRealTimeDamage = useCallback(
 		(elapsedMs: number, startTime: Date) => {
-			const currentTime = addMilliseconds(startTime, elapsedMs);
-			let totalDamage = 0;
+			const currentTimeMs = addMilliseconds(startTime, elapsedMs).getTime();
+			let latestDamage = 0;
 
-			// Find relevant calculation points for the elapsed time
-			for (const point of result.points) {
-				if (point.slice.datetime <= currentTime) {
-					totalDamage += point.burnCost;
-				} else {
-					// Interpolate partial damage for current time slice
-					const prevPoint = result.points[result.points.indexOf(point) - 1];
-					if (prevPoint && prevPoint.slice.datetime <= startTime) {
-						const sliceDuration =
-							point.slice.datetime.getTime() -
-							prevPoint.slice.datetime.getTime();
-						const elapsedInSlice =
-							currentTime.getTime() - prevPoint.slice.datetime.getTime();
-						const partialDamage =
-							(elapsedInSlice / sliceDuration) * point.burnCost;
-						totalDamage += Math.min(partialDamage, point.burnCost);
-					}
-					break;
+			for (let index = 0; index < result.points.length; index++) {
+				const point = result.points[index];
+				const pointStartMs = point.slice.datetime.getTime();
+				const nextPointStartMs =
+					result.points[index + 1]?.slice.datetime.getTime();
+				const previousPointStartMs =
+					result.points[index - 1]?.slice.datetime.getTime();
+				const inferredEndMs =
+					nextPointStartMs ??
+					result.burnTime?.getTime() ??
+					(previousPointStartMs
+						? pointStartMs + (pointStartMs - previousPointStartMs)
+						: pointStartMs);
+				const pointEndMs = Math.max(pointStartMs, inferredEndMs);
+				const pointEndDamage = point.totalDamageAtStart + point.burnCost;
+
+				if (currentTimeMs < pointStartMs) {
+					return Math.max(0, Math.min(latestDamage, 100));
 				}
+
+				if (currentTimeMs <= pointEndMs) {
+					const durationMs = pointEndMs - pointStartMs;
+					const progress =
+						durationMs > 0
+							? Math.max(
+									0,
+									Math.min(1, (currentTimeMs - pointStartMs) / durationMs),
+								)
+							: 1;
+					const interpolatedDamage =
+						point.totalDamageAtStart +
+						(pointEndDamage - point.totalDamageAtStart) * progress;
+					return Math.max(0, Math.min(interpolatedDamage, 100));
+				}
+
+				latestDamage = pointEndDamage;
 			}
 
-			return Math.min(totalDamage, 100);
+			return Math.max(0, Math.min(latestDamage, 100));
 		},
-		[result.points],
+		[result.burnTime, result.points],
 	);
 
 	// Timer effect

--- a/src/components/SweatLevelSelector.tsx
+++ b/src/components/SweatLevelSelector.tsx
@@ -49,12 +49,12 @@ function SweatLevelOption({
 			onClick={() => onSelect(level)}
 			aria-label={`Select ${config.label} sweating level`}
 		>
-			<CardContent className="p-4">
+			<CardContent className="p-3">
 				<div className="flex items-center justify-between">
-					<div className="flex items-center space-x-4">
+					<div className="flex items-center gap-3">
 						<div
 							className={`
-              flex items-center justify-center w-12 h-12 rounded-full
+              flex h-9 w-9 items-center justify-center rounded-full
               ${selected ? "bg-primary" : "bg-muted"}
             `}
 						>
@@ -78,8 +78,8 @@ function SweatLevelOption({
 						</div>
 
 						<div className="text-left">
-							<div className="font-semibold">{config.label}</div>
-							<div className="text-sm text-muted-foreground">
+							<div className="text-sm font-semibold">{config.label}</div>
+							<div className="text-xs text-muted-foreground">
 								{getDescription(level)}
 							</div>
 							{level !== SweatLevel.LOW && (
@@ -111,7 +111,7 @@ export function SweatLevelSelector() {
 				wears off.
 			</p>
 
-			<div className="space-y-4">
+			<div className="grid gap-3 lg:grid-cols-3">
 				{Object.values(SweatLevel).map((level) => (
 					<SweatLevelOption
 						key={level}

--- a/src/components/UVChart.tsx
+++ b/src/components/UVChart.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from "react";
+import { useCallback, useMemo, useState } from "react";
 import {
 	CategoryScale,
 	Chart as ChartJS,
@@ -16,12 +16,19 @@ import {
 import annotationPlugin from "chartjs-plugin-annotation";
 import { Line } from "react-chartjs-2";
 import { format } from "date-fns";
+import { CalendarDays, Clock } from "lucide-react";
 import "chartjs-adapter-date-fns";
 import type { CalculationResult } from "../types";
 import { Card, CardContent, CardHeader, CardTitle } from "./ui/card";
 import { useAppStore } from "../store";
 import { getUVIndexColor } from "../lib/utils";
-import { toTZDate, formatInTimeZone } from "../utils/timezone";
+import { Button } from "./ui/button";
+import {
+	buildFallbackUVSeriesForRange,
+	buildUVSeriesForRange,
+	type UVSeriesPoint,
+} from "../lib/uvSeries";
+import { formatInTimeZone, getDayBoundsInTimeZone } from "../utils/timezone";
 
 ChartJS.register(
 	CategoryScale,
@@ -39,49 +46,91 @@ ChartJS.register(
 interface UVChartProps {
 	result: CalculationResult;
 	timezone?: string;
+	activityStartTime: Date;
+	activityDurationMinutes: number;
 }
 
-export function UVChart({ result, timezone }: UVChartProps) {
+const UVChartViewMode = {
+	ACTIVITY: "activity",
+	DAY: "day",
+} as const;
+
+type UVChartViewMode = (typeof UVChartViewMode)[keyof typeof UVChartViewMode];
+
+function addMinutes(date: Date, minutes: number): Date {
+	return new Date(date.getTime() + minutes * 60000);
+}
+
+function formatChartTime(date: Date, timezone?: string): string {
+	return timezone
+		? formatInTimeZone(date, timezone, "h:mm a")
+		: format(date, "h:mm a");
+}
+
+function formatChartDateTime(date: Date, timezone?: string): string {
+	return timezone
+		? formatInTimeZone(date, timezone, "MMM d, h:mm a")
+		: format(date, "MMM d, h:mm a");
+}
+
+function getVisibleUVStats(points: UVSeriesPoint[]): {
+	startUV: number;
+	peakUV: number;
+} {
+	const uvValues = points.map((point) => point.uvIndex);
+	const startUV = uvValues[0] ?? 0;
+	const peakUV = uvValues.length > 0 ? Math.max(...uvValues) : 0;
+
+	return { startUV, peakUV };
+}
+
+export function UVChart({
+	result,
+	timezone,
+	activityStartTime,
+	activityDurationMinutes,
+}: UVChartProps) {
+	const [viewMode, setViewMode] = useState<UVChartViewMode>(
+		UVChartViewMode.ACTIVITY,
+	);
 	const { geolocation } = useAppStore();
 
-	// Calculate UV statistics from weather data or fallback to calculation points
 	const weatherData = geolocation.weather;
-	let currentUV: number;
-	let maxUV: number;
+	const activityRange = useMemo(
+		() => ({
+			start: activityStartTime,
+			end: addMinutes(activityStartTime, activityDurationMinutes),
+		}),
+		[activityStartTime, activityDurationMinutes],
+	);
+	const dayRange = useMemo(
+		() => getDayBoundsInTimeZone(activityStartTime, timezone),
+		[activityStartTime, timezone],
+	);
+	const visibleRange =
+		viewMode === UVChartViewMode.ACTIVITY ? activityRange : dayRange;
+	const chartPoints = useMemo(() => {
+		const points =
+			weatherData && weatherData.hourly.length > 0
+				? buildUVSeriesForRange(weatherData.hourly, visibleRange)
+				: buildFallbackUVSeriesForRange(result.points, visibleRange);
 
-	if (weatherData && weatherData.hourly.length > 0) {
-		currentUV = weatherData.current.uvi;
-		maxUV = Math.max(...weatherData.hourly.map((h) => h.uvi));
-	} else {
-		currentUV = result.points[0]?.slice.uvIndex || 0;
-		maxUV = Math.max(...result.points.map((p) => p.slice.uvIndex));
-	}
+		if (points.length > 0) return points;
+
+		return result.points.map((point) => ({
+			datetime: point.slice.datetime,
+			uvIndex: point.slice.uvIndex,
+		}));
+	}, [result.points, visibleRange, weatherData]);
+	const { startUV, peakUV } = getVisibleUVStats(chartPoints);
 
 	const chartData = useMemo(() => {
-		// Use full weather data instead of just calculation points for better forecast visualization
-		let times: Date[];
-		let uvData: number[];
-
-		if (!weatherData) {
-			// Fallback to calculation points if no weather data
-			times = result.points.map((point) =>
-				toTZDate(point.slice.datetime, timezone),
-			);
-			uvData = result.points.map((point) => point.slice.uvIndex);
-		} else {
-			// Show UV data for the next 3 days (up to 72 hours)
-			times = weatherData.hourly.map((hour) =>
-				toTZDate(new Date(hour.dt * 1000), timezone),
-			);
-			uvData = weatherData.hourly.map((hour) => hour.uvi);
-		}
-
 		return {
-			labels: times,
+			labels: chartPoints.map((point) => point.datetime),
 			datasets: [
 				{
 					label: "UV Index",
-					data: uvData,
+					data: chartPoints.map((point) => point.uvIndex),
 					borderColor: "#f59e0b", // amber-500
 					backgroundColor: (context: ScriptableContext<"line">) => {
 						const ctx = context.chart.ctx;
@@ -105,7 +154,7 @@ export function UVChart({ result, timezone }: UVChartProps) {
 				},
 			],
 		};
-	}, [result.points, weatherData?.hourly.map, weatherData, timezone]);
+	}, [chartPoints]);
 
 	const getUVRiskLevel = useCallback((uvIndex: number): string => {
 		if (uvIndex < 3) return "Low";
@@ -136,9 +185,7 @@ export function UVChart({ result, timezone }: UVChartProps) {
 					callbacks: {
 						title: (context: TooltipItem<"line">[]) => {
 							const date = new Date(context[0].parsed.x);
-							return timezone
-								? formatInTimeZone(date, timezone, "h:mm a")
-								: format(date, "h:mm a");
+							return formatChartDateTime(date, timezone);
 						},
 						label: (context: TooltipItem<"line">) => {
 							const uvIndex = context.parsed.y.toFixed(1);
@@ -149,15 +196,16 @@ export function UVChart({ result, timezone }: UVChartProps) {
 				},
 				annotation: {
 					annotations: {
-						currentTime: {
+						activityStart: {
 							type: "line" as const,
-							xMin: Date.now(),
-							xMax: Date.now(),
-							borderColor: "#dc2626", // red-600
+							xMin: activityRange.start.getTime(),
+							xMax: activityRange.start.getTime(),
+							borderColor: "#dc2626",
 							borderWidth: 2,
 							borderDash: [3, 3],
 							label: {
-								content: "Now",
+								content:
+									viewMode === UVChartViewMode.ACTIVITY ? "Start" : "Plan",
 								enabled: true,
 								position: "start" as const,
 								backgroundColor: "#dc2626",
@@ -170,15 +218,47 @@ export function UVChart({ result, timezone }: UVChartProps) {
 								},
 							},
 						},
+						...(viewMode === UVChartViewMode.ACTIVITY
+							? {
+									activityEnd: {
+										type: "line" as const,
+										xMin: activityRange.end.getTime(),
+										xMax: activityRange.end.getTime(),
+										borderColor: "#475569",
+										borderWidth: 2,
+										borderDash: [3, 3],
+										label: {
+											content: "End",
+											enabled: true,
+											position: "end" as const,
+											backgroundColor: "#475569",
+											color: "white",
+											padding: 4,
+											borderRadius: 4,
+											font: {
+												size: 10,
+												weight: "bold" as const,
+											},
+										},
+									},
+								}
+							: {}),
 					},
 				},
 			},
 			scales: {
 				x: {
 					type: "time" as const,
+					min: visibleRange.start.getTime(),
+					max: visibleRange.end.getTime(),
 					time: {
-						unit: "hour" as const,
+						unit:
+							viewMode === UVChartViewMode.ACTIVITY &&
+							activityDurationMinutes <= 180
+								? ("minute" as const)
+								: ("hour" as const),
 						displayFormats: {
+							minute: "h:mm a",
 							hour: "h a",
 						},
 					},
@@ -198,15 +278,17 @@ export function UVChart({ result, timezone }: UVChartProps) {
 						color: "#64748b",
 						callback: (value: string | number) => {
 							const date = new Date(value as number);
-							return timezone
-								? formatInTimeZone(date, timezone, "h a")
-								: format(date, "h a");
+							return viewMode === UVChartViewMode.ACTIVITY
+								? formatChartTime(date, timezone)
+								: timezone
+									? formatInTimeZone(date, timezone, "h a")
+									: format(date, "h a");
 						},
 					},
 				},
 				y: {
 					min: 0,
-					max: Math.max(12, Math.ceil(maxUV + 1)),
+					max: Math.max(12, Math.ceil(peakUV + 1)),
 					title: {
 						display: true,
 						text: "UV Index",
@@ -231,7 +313,15 @@ export function UVChart({ result, timezone }: UVChartProps) {
 				},
 			},
 		}),
-		[maxUV, getUVRiskLevel, timezone],
+		[
+			activityDurationMinutes,
+			activityRange,
+			getUVRiskLevel,
+			peakUV,
+			timezone,
+			viewMode,
+			visibleRange,
+		],
 	);
 
 	const getUVRiskColor = (uvIndex: number): string => {
@@ -245,27 +335,61 @@ export function UVChart({ result, timezone }: UVChartProps) {
 	return (
 		<Card className="border-stone-200 shadow-sm">
 			<CardHeader>
-				<CardTitle className="flex items-center justify-between text-slate-800">
-					<span>UV Index Throughout the Day</span>
-					<div className="flex items-center space-x-4 text-sm">
+				<CardTitle className="flex flex-col gap-3 text-slate-800 sm:flex-row sm:items-start sm:justify-between">
+					<div>
+						<span>
+							{viewMode === UVChartViewMode.ACTIVITY
+								? "UV Index During Activity"
+								: "UV Index on Planned Day"}
+						</span>
+						<p className="mt-1 text-sm font-normal text-slate-600">
+							{formatChartDateTime(visibleRange.start, timezone)} to{" "}
+							{viewMode === UVChartViewMode.ACTIVITY
+								? formatChartDateTime(visibleRange.end, timezone)
+								: formatChartTime(visibleRange.end, timezone)}
+						</p>
+					</div>
+					<div className="flex items-center justify-between gap-4 text-sm sm:justify-end">
 						<div className="text-center">
-							<p className="text-xs text-slate-600">Current</p>
+							<p className="text-xs text-slate-600">Start</p>
 							<p
-								className={`font-bold tabular-nums ${getUVRiskColor(currentUV)}`}
+								className={`font-bold tabular-nums ${getUVRiskColor(startUV)}`}
 							>
-								{currentUV.toFixed(1)}
+								{startUV.toFixed(1)}
 							</p>
 						</div>
 						<div className="text-center">
 							<p className="text-xs text-slate-600">Peak</p>
-							<p className={`font-bold tabular-nums ${getUVRiskColor(maxUV)}`}>
-								{maxUV.toFixed(1)}
+							<p className={`font-bold tabular-nums ${getUVRiskColor(peakUV)}`}>
+								{peakUV.toFixed(1)}
 							</p>
 						</div>
 					</div>
 				</CardTitle>
 			</CardHeader>
 			<CardContent>
+				<div className="mb-4 grid grid-cols-2 gap-1 rounded-md border border-stone-200 bg-stone-50 p-1">
+					<Button
+						type="button"
+						size="sm"
+						variant={
+							viewMode === UVChartViewMode.ACTIVITY ? "default" : "ghost"
+						}
+						onClick={() => setViewMode(UVChartViewMode.ACTIVITY)}
+					>
+						<Clock className="size-4" />
+						Activity
+					</Button>
+					<Button
+						type="button"
+						size="sm"
+						variant={viewMode === UVChartViewMode.DAY ? "default" : "ghost"}
+						onClick={() => setViewMode(UVChartViewMode.DAY)}
+					>
+						<CalendarDays className="size-4" />
+						Day
+					</Button>
+				</div>
 				<div className="h-64 w-full mb-4">
 					<Line data={chartData} options={options} />
 				</div>
@@ -306,8 +430,9 @@ export function UVChart({ result, timezone }: UVChartProps) {
 
 				<div className="mt-4 text-sm text-slate-600">
 					<p>
-						The UV Index measures the strength of ultraviolet radiation. Higher
-						values indicate greater risk of sunburn and need for protection.
+						The UV Index measures ultraviolet radiation strength. Activity view
+						uses the planned start and time outside. Day view is limited to that
+						local calendar day.
 					</p>
 				</div>
 			</CardContent>

--- a/src/hooks/useLocationRefresh.ts
+++ b/src/hooks/useLocationRefresh.ts
@@ -1,10 +1,19 @@
 import { useEffect } from "react";
 import { useAppStore } from "../store";
-import { fetchWeatherData } from "../services/weather";
+import {
+	fetchWeatherData,
+	getActiveWeatherProvider,
+	isGoogleWeatherTestRoute,
+} from "../services/weather";
 
 export function useLocationRefresh() {
-	const { geolocation, setGeolocationStatus, setWeather, setGeolocationError } =
-		useAppStore();
+	const {
+		geolocation,
+		weatherProvider,
+		setGeolocationStatus,
+		setWeather,
+		setGeolocationError,
+	} = useAppStore();
 
 	useEffect(() => {
 		// If we have a saved location but no weather data, refresh the weather
@@ -17,7 +26,14 @@ export function useLocationRefresh() {
 			const refreshWeather = async () => {
 				try {
 					setGeolocationStatus("fetching_weather");
-					const weather = await fetchWeatherData(position);
+					const activeWeatherProvider =
+						isGoogleWeatherTestRoute() && weatherProvider
+							? weatherProvider
+							: getActiveWeatherProvider();
+					const weather = await fetchWeatherData(
+						position,
+						activeWeatherProvider,
+					);
 					setWeather(weather);
 				} catch (error) {
 					setGeolocationError(
@@ -34,6 +50,7 @@ export function useLocationRefresh() {
 		geolocation.status,
 		geolocation.position,
 		geolocation.weather,
+		weatherProvider,
 		setGeolocationStatus,
 		setWeather,
 		setGeolocationError,

--- a/src/lib/units.ts
+++ b/src/lib/units.ts
@@ -1,0 +1,29 @@
+import { UnitSystem, type UnitSystem as UnitSystemType } from "../types";
+
+export function formatTemperature(
+	fahrenheit: number,
+	unitSystem: UnitSystemType,
+): string {
+	if (unitSystem === UnitSystem.METRIC) {
+		const celsius = ((fahrenheit - 32) * 5) / 9;
+		return `${Math.round(celsius)}°C`;
+	}
+
+	return `${Math.round(fahrenheit)}°F`;
+}
+
+export function formatElevation(
+	meters: number,
+	unitSystem: UnitSystemType,
+): string {
+	if (unitSystem === UnitSystem.IMPERIAL) {
+		const feet = Math.round(meters * 3.28084);
+		return `${feet.toLocaleString()} ft`;
+	}
+
+	return `${Math.round(meters).toLocaleString()} m`;
+}
+
+export function getDistanceLabel(unitSystem: UnitSystemType): string {
+	return unitSystem === UnitSystem.METRIC ? "km" : "mi";
+}

--- a/src/lib/uvSeries.test.ts
+++ b/src/lib/uvSeries.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "bun:test";
+import type { HourlyWeather } from "../types";
+import { buildUVSeriesForRange, getUVIndexAtTime } from "./uvSeries";
+
+function createHourlyForecast(
+	values: number[],
+	startTime: Date,
+): HourlyWeather[] {
+	return values.map((uvi, index) => ({
+		dt: Math.floor(startTime.getTime() / 1000) + index * 3600,
+		temp: 75,
+		uvi,
+		weather: [
+			{ id: 800, main: "Clear", description: "clear sky", icon: "01d" },
+		],
+	}));
+}
+
+describe("UV series helpers", () => {
+	const forecastStart = new Date("2026-06-15T12:00:00Z");
+	const hourly = createHourlyForecast([0, 4, 8, 4], forecastStart);
+
+	it("interpolates UV Index between hourly forecast points", () => {
+		const value = getUVIndexAtTime(hourly, new Date("2026-06-15T12:30:00Z"));
+
+		expect(value).toBe(2);
+	});
+
+	it("builds a focused range with interpolated start and end points", () => {
+		const series = buildUVSeriesForRange(hourly, {
+			start: new Date("2026-06-15T12:30:00Z"),
+			end: new Date("2026-06-15T14:30:00Z"),
+		});
+
+		expect(series.map((point) => point.datetime.toISOString())).toEqual([
+			"2026-06-15T12:30:00.000Z",
+			"2026-06-15T13:00:00.000Z",
+			"2026-06-15T14:00:00.000Z",
+			"2026-06-15T14:30:00.000Z",
+		]);
+		expect(series.map((point) => point.uvIndex)).toEqual([2, 4, 8, 6]);
+	});
+});

--- a/src/lib/uvSeries.ts
+++ b/src/lib/uvSeries.ts
@@ -1,0 +1,117 @@
+import type { CalculationPoint, HourlyWeather } from "../types";
+
+export interface UVSeriesRange {
+	start: Date;
+	end: Date;
+}
+
+export interface UVSeriesPoint {
+	datetime: Date;
+	uvIndex: number;
+}
+
+interface ForecastPoint {
+	timestampMs: number;
+	uvIndex: number;
+}
+
+function normalizeForecast(hourly: HourlyWeather[]): ForecastPoint[] {
+	return hourly
+		.map((hour) => ({
+			timestampMs: hour.dt * 1000,
+			uvIndex: hour.uvi,
+		}))
+		.filter(
+			(point) =>
+				Number.isFinite(point.timestampMs) && Number.isFinite(point.uvIndex),
+		)
+		.sort((left, right) => left.timestampMs - right.timestampMs);
+}
+
+export function getUVIndexAtTime(
+	hourly: HourlyWeather[],
+	targetTime: Date,
+): number | undefined {
+	const forecast = normalizeForecast(hourly);
+	if (forecast.length === 0) return undefined;
+
+	const targetMs = targetTime.getTime();
+	if (targetMs <= forecast[0].timestampMs) return forecast[0].uvIndex;
+
+	const lastPoint = forecast[forecast.length - 1];
+	if (targetMs >= lastPoint.timestampMs) return lastPoint.uvIndex;
+
+	for (let index = 0; index < forecast.length - 1; index++) {
+		const start = forecast[index];
+		const end = forecast[index + 1];
+
+		if (targetMs === start.timestampMs) return start.uvIndex;
+		if (targetMs > start.timestampMs && targetMs <= end.timestampMs) {
+			const durationMs = end.timestampMs - start.timestampMs;
+			if (durationMs <= 0) return start.uvIndex;
+
+			const progress = (targetMs - start.timestampMs) / durationMs;
+			return start.uvIndex + (end.uvIndex - start.uvIndex) * progress;
+		}
+	}
+
+	return undefined;
+}
+
+export function buildUVSeriesForRange(
+	hourly: HourlyWeather[],
+	range: UVSeriesRange,
+): UVSeriesPoint[] {
+	const startMs = range.start.getTime();
+	const endMs = range.end.getTime();
+	if (!(endMs > startMs)) return [];
+
+	const forecast = normalizeForecast(hourly);
+	const points = new Map<number, UVSeriesPoint>();
+
+	const addPoint = (timestampMs: number, uvIndex: number | undefined) => {
+		if (
+			!Number.isFinite(timestampMs) ||
+			typeof uvIndex !== "number" ||
+			!Number.isFinite(uvIndex)
+		) {
+			return;
+		}
+		points.set(timestampMs, {
+			datetime: new Date(timestampMs),
+			uvIndex,
+		});
+	};
+
+	addPoint(startMs, getUVIndexAtTime(hourly, range.start));
+
+	for (const point of forecast) {
+		if (point.timestampMs > startMs && point.timestampMs < endMs) {
+			addPoint(point.timestampMs, point.uvIndex);
+		}
+	}
+
+	addPoint(endMs, getUVIndexAtTime(hourly, range.end));
+
+	return Array.from(points.values()).sort(
+		(left, right) => left.datetime.getTime() - right.datetime.getTime(),
+	);
+}
+
+export function buildFallbackUVSeriesForRange(
+	points: CalculationPoint[],
+	range: UVSeriesRange,
+): UVSeriesPoint[] {
+	const startMs = range.start.getTime();
+	const endMs = range.end.getTime();
+
+	return points
+		.filter((point) => {
+			const timestampMs = point.slice.datetime.getTime();
+			return timestampMs >= startMs && timestampMs <= endMs;
+		})
+		.map((point) => ({
+			datetime: point.slice.datetime,
+			uvIndex: point.slice.uvIndex,
+		}));
+}

--- a/src/services/weather.test.ts
+++ b/src/services/weather.test.ts
@@ -42,6 +42,9 @@ describe("weather providers", () => {
 	it("labels weather providers for compact UI display", () => {
 		expect(getWeatherProviderLabel("open-meteo")).toBe("Open-Meteo");
 		expect(getWeatherProviderLabel("google")).toBe("Google");
+		expect(getWeatherProviderLabel("current-uv-index")).toBe(
+			"CurrentUVIndex + MET Norway",
+		);
 		expect(getWeatherProviderLabel(undefined)).toBe("Open-Meteo");
 	});
 });

--- a/src/services/weather.test.ts
+++ b/src/services/weather.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "bun:test";
+import { getWeatherProviderLabel, normalizeGoogleWeatherData } from "./weather";
+
+describe("weather providers", () => {
+	it("normalizes Google hourly weather into app weather data", () => {
+		const weather = normalizeGoogleWeatherData(
+			{
+				timeZone: { id: "America/Denver" },
+				forecastHours: [
+					{
+						interval: { startTime: "2026-06-15T15:00:00Z" },
+						temperature: { degrees: 75 },
+						uvIndex: 7,
+						weatherCondition: {
+							type: "CLEAR",
+							description: { text: "Clear" },
+						},
+					},
+					{
+						interval: { startTime: "2026-06-15T16:00:00Z" },
+						temperature: { degrees: 78 },
+						uvIndex: 8,
+					},
+				],
+			},
+			{
+				elevation: 1609,
+				sunrise: "2026-06-15T05:30",
+				sunset: "2026-06-15T20:31",
+				nextSunrise: "2026-06-16T05:30",
+				timezone: "America/Denver",
+			},
+		);
+
+		expect(weather.provider).toBe("google");
+		expect(weather.current.uvi).toBe(7);
+		expect(weather.hourly).toHaveLength(2);
+		expect(weather.hourly[1].temp).toBe(78);
+		expect(weather.timezone).toBe("America/Denver");
+	});
+
+	it("labels weather providers for compact UI display", () => {
+		expect(getWeatherProviderLabel("open-meteo")).toBe("Open-Meteo");
+		expect(getWeatherProviderLabel("google")).toBe("Google");
+		expect(getWeatherProviderLabel(undefined)).toBe("Open-Meteo");
+	});
+});

--- a/src/services/weather.ts
+++ b/src/services/weather.ts
@@ -91,6 +91,11 @@ export async function fetchWeatherData(
 export async function fetchOpenMeteoWeatherData(
 	position: Position,
 ): Promise<WeatherData> {
+	const proxiedWeather = await fetchOpenMeteoWeatherDataFromApi(position);
+	if (proxiedWeather) {
+		return proxiedWeather;
+	}
+
 	const lat = position.latitude.toFixed(4);
 	const lon = position.longitude.toFixed(4);
 
@@ -199,6 +204,43 @@ export async function fetchOpenMeteoWeatherData(
 		).toISOString(),
 		timezone: locationTimezone,
 	};
+}
+
+async function fetchOpenMeteoWeatherDataFromApi(
+	position: Position,
+): Promise<WeatherData | undefined> {
+	if (typeof window === "undefined") {
+		return undefined;
+	}
+
+	const params = new URLSearchParams({
+		latitude: position.latitude.toString(),
+		longitude: position.longitude.toString(),
+		timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+	});
+
+	let response: Response;
+	try {
+		response = await fetch(`/api/open-meteo-weather?${params.toString()}`, {
+			headers: {
+				Accept: "application/json",
+			},
+		});
+	} catch {
+		return undefined;
+	}
+
+	const contentType = response.headers.get("content-type");
+	if (!contentType?.includes("application/json")) {
+		return undefined;
+	}
+
+	if (!response.ok) {
+		const message = await readErrorMessage(response);
+		throw new Error(message || `Weather API error: ${response.status}`);
+	}
+
+	return response.json();
 }
 
 async function fetchGoogleWeatherData(
@@ -321,8 +363,25 @@ export function getWeatherProviderLabel(
 	switch (provider) {
 		case "google":
 			return "Google";
+		case "current-uv-index":
+			return "CurrentUVIndex + MET Norway";
 		case "open-meteo":
 		case undefined:
 			return "Open-Meteo";
+	}
+}
+
+export function getWeatherProviderUrl(
+	provider: ActualWeatherProvider | undefined,
+): string | undefined {
+	switch (provider) {
+		case "current-uv-index":
+			return "https://currentuvindex.com";
+		case "google":
+			return "https://weather.google.com";
+		case "open-meteo":
+			return "https://open-meteo.com";
+		case undefined:
+			return undefined;
 	}
 }

--- a/src/services/weather.ts
+++ b/src/services/weather.ts
@@ -1,5 +1,11 @@
 import { TZDate } from "@date-fns/tz";
-import type { Position, WeatherData, AQIData } from "../types";
+import type {
+	ActualWeatherProvider,
+	Position,
+	WeatherData,
+	AQIData,
+	WeatherProvider,
+} from "../types";
 import { WMO_DESCRIPTIONS } from "../constants/wmo-descriptions";
 import { fetchAQIData } from "./aqi";
 
@@ -24,6 +30,33 @@ interface OpenMeteoResponse {
 	};
 }
 
+interface GoogleForecastHour {
+	interval?: {
+		startTime?: string;
+	};
+	weatherCondition?: {
+		iconBaseUri?: string;
+		type?: string;
+		description?: {
+			text?: string;
+		};
+	};
+	temperature?: {
+		degrees?: number;
+	};
+	uvIndex?: number;
+}
+
+interface GoogleHourlyResponse {
+	forecastHours?: GoogleForecastHour[];
+	timeZone?: {
+		id?: string;
+	};
+	nextPageToken?: string;
+}
+
+const GOOGLE_FORECAST_HOURS = 72;
+
 /**
  * Parse a naive datetime string from Open-Meteo (e.g. "2026-02-22T14:00")
  * as local time in the given IANA timezone, returning a UTC timestamp (ms).
@@ -35,7 +68,27 @@ function parseLocationTime(timeStr: string, timezone: string): number {
 	return new TZDate(y, m - 1, d, h, min, 0, timezone).getTime();
 }
 
+export function isGoogleWeatherTestRoute(): boolean {
+	if (typeof window === "undefined") return false;
+	return window.location.pathname.replace(/\/+$/, "") === "/google";
+}
+
+export function getActiveWeatherProvider(): WeatherProvider {
+	return isGoogleWeatherTestRoute() ? "google" : "open-meteo";
+}
+
 export async function fetchWeatherData(
+	position: Position,
+	provider: WeatherProvider = getActiveWeatherProvider(),
+): Promise<WeatherData> {
+	if (provider === "google") {
+		return fetchGoogleWeatherData(position);
+	}
+
+	return fetchOpenMeteoWeatherData(position);
+}
+
+export async function fetchOpenMeteoWeatherData(
 	position: Position,
 ): Promise<WeatherData> {
 	const lat = position.latitude.toFixed(4);
@@ -130,6 +183,7 @@ export async function fetchWeatherData(
 	}
 
 	return {
+		provider: "open-meteo",
 		current,
 		hourly,
 		elevation: data.elevation,
@@ -145,4 +199,130 @@ export async function fetchWeatherData(
 		).toISOString(),
 		timezone: locationTimezone,
 	};
+}
+
+async function fetchGoogleWeatherData(
+	position: Position,
+): Promise<WeatherData> {
+	const params = new URLSearchParams({
+		latitude: position.latitude.toString(),
+		longitude: position.longitude.toString(),
+	});
+
+	const response = await fetch(`/api/google-weather?${params.toString()}`, {
+		headers: {
+			Accept: "application/json",
+		},
+	});
+
+	if (!response.ok) {
+		const message = await readErrorMessage(response);
+		throw new Error(message || `Google Weather API error: ${response.status}`);
+	}
+
+	const contentType = response.headers.get("content-type");
+	if (!contentType?.includes("application/json")) {
+		throw new Error(
+			"Google weather needs Vercel dev or a Vercel preview deployment.",
+		);
+	}
+
+	return response.json();
+}
+
+async function readErrorMessage(
+	response: Response,
+): Promise<string | undefined> {
+	const contentType = response.headers.get("content-type");
+
+	if (contentType?.includes("application/json")) {
+		const body = (await response.json().catch(() => undefined)) as
+			| { error?: string }
+			| undefined;
+		return body?.error;
+	}
+
+	return response.text().catch(() => undefined);
+}
+
+export function normalizeGoogleWeatherData(
+	googleWeather: GoogleHourlyResponse,
+	metadata: Pick<
+		WeatherData,
+		"elevation" | "sunrise" | "sunset" | "nextSunrise" | "timezone" | "aqi"
+	>,
+): WeatherData {
+	const timezone = googleWeather.timeZone?.id || metadata.timezone;
+	if (!timezone) {
+		throw new Error("Missing weather timezone");
+	}
+
+	const hourly = (googleWeather.forecastHours ?? []).flatMap((hour) => {
+		const startTime = hour.interval?.startTime;
+		const temperature = hour.temperature?.degrees;
+		const uvIndex = hour.uvIndex;
+
+		if (
+			!startTime ||
+			typeof temperature !== "number" ||
+			typeof uvIndex !== "number"
+		) {
+			return [];
+		}
+
+		return [
+			{
+				dt: Math.floor(Date.parse(startTime) / 1000),
+				temp: temperature,
+				uvi: uvIndex,
+				weather: [normalizeGoogleWeatherOverview(hour)],
+			},
+		];
+	});
+	const filteredHourly = hourly.slice(0, GOOGLE_FORECAST_HOURS);
+	const current = filteredHourly[0];
+	if (!current) {
+		throw new Error("Invalid Google weather data received");
+	}
+
+	return {
+		provider: "google",
+		current,
+		hourly: filteredHourly,
+		elevation: metadata.elevation,
+		aqi: metadata.aqi,
+		sunrise: metadata.sunrise,
+		sunset: metadata.sunset,
+		nextSunrise: metadata.nextSunrise,
+		timezone,
+	};
+}
+
+function normalizeGoogleWeatherOverview(hour: GoogleForecastHour) {
+	const type = hour.weatherCondition?.type ?? "UNKNOWN";
+	const description =
+		hour.weatherCondition?.description?.text ?? type.replaceAll("_", " ");
+
+	return {
+		id: 800,
+		main: toTitleCase(type.replaceAll("_", " ").toLowerCase()),
+		description,
+		icon: hour.weatherCondition?.iconBaseUri ?? "",
+	};
+}
+
+function toTitleCase(value: string): string {
+	return value.replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+export function getWeatherProviderLabel(
+	provider: ActualWeatherProvider | undefined,
+): string {
+	switch (provider) {
+		case "google":
+			return "Google";
+		case "open-meteo":
+		case undefined:
+			return "Open-Meteo";
+	}
 }

--- a/src/store.ts
+++ b/src/store.ts
@@ -6,12 +6,20 @@ import type {
 	GeolocationState,
 	Position,
 	WeatherData,
+	WeatherProvider,
 } from "./types";
 import {
 	type FitzpatrickType,
 	SPFLevel,
 	type SweatLevel,
 	DEFAULT_SWEAT_LEVEL,
+	type UnitSystem,
+	DEFAULT_UNIT_SYSTEM,
+	type StartTimeMode,
+	DEFAULT_START_TIME_MODE,
+	type ExposureGoal,
+	DEFAULT_EXPOSURE_GOAL,
+	DEFAULT_PLANNED_DURATION_MINUTES,
 } from "./types";
 
 interface AppStore extends AppState {
@@ -19,6 +27,12 @@ interface AppStore extends AppState {
 	setSkinType: (skinType: FitzpatrickType) => void;
 	setSPFLevel: (spfLevel: SPFLevel) => void;
 	setSweatLevel: (sweatLevel: SweatLevel) => void;
+	setUnitSystem: (unitSystem: UnitSystem) => void;
+	setStartTimeMode: (startTimeMode: StartTimeMode) => void;
+	setPlannedStartTime: (plannedStartTime: string) => void;
+	setPlannedDurationMinutes: (plannedDurationMinutes: number) => void;
+	setExposureGoal: (exposureGoal: ExposureGoal) => void;
+	setWeatherProvider: (weatherProvider: WeatherProvider) => void;
 	setGeolocationStatus: (status: GeolocationState["status"]) => void;
 	setPosition: (
 		position: Position,
@@ -33,6 +47,10 @@ interface AppStore extends AppState {
 }
 
 const initialState: AppState = {
+	unitSystem: DEFAULT_UNIT_SYSTEM,
+	startTimeMode: DEFAULT_START_TIME_MODE,
+	plannedDurationMinutes: DEFAULT_PLANNED_DURATION_MINUTES,
+	exposureGoal: DEFAULT_EXPOSURE_GOAL,
 	geolocation: {
 		status: "blank",
 	},
@@ -57,6 +75,33 @@ export const useAppStore = create<AppStore>()(
 				})),
 
 			setSweatLevel: (sweatLevel) => set((state) => ({ ...state, sweatLevel })),
+
+			setUnitSystem: (unitSystem) => set((state) => ({ ...state, unitSystem })),
+
+			setStartTimeMode: (startTimeMode) =>
+				set((state) => ({ ...state, startTimeMode })),
+
+			setPlannedStartTime: (plannedStartTime) =>
+				set((state) => ({ ...state, plannedStartTime })),
+
+			setPlannedDurationMinutes: (plannedDurationMinutes) =>
+				set((state) => ({ ...state, plannedDurationMinutes })),
+
+			setExposureGoal: (exposureGoal) =>
+				set((state) => ({ ...state, exposureGoal })),
+
+			setWeatherProvider: (weatherProvider) =>
+				set((state) => ({
+					...state,
+					weatherProvider,
+					calculation: undefined,
+					geolocation: {
+						...state.geolocation,
+						weather: undefined,
+						lastFetched: undefined,
+						error: undefined,
+					},
+				})),
 
 			setGeolocationStatus: (status) =>
 				set((state) => ({
@@ -111,6 +156,12 @@ export const useAppStore = create<AppStore>()(
 				skinType: state.skinType,
 				spfLevel: state.spfLevel,
 				sweatLevel: state.sweatLevel,
+				unitSystem: state.unitSystem,
+				startTimeMode: state.startTimeMode,
+				plannedStartTime: state.plannedStartTime,
+				plannedDurationMinutes: state.plannedDurationMinutes,
+				exposureGoal: state.exposureGoal,
+				weatherProvider: state.weatherProvider,
 				geolocation:
 					state.geolocation.status === "completed" && state.geolocation.position
 						? {

--- a/src/types.ts
+++ b/src/types.ts
@@ -235,8 +235,11 @@ export interface AQIData {
 	us_aqi: number;
 }
 
-export type ActualWeatherProvider = "open-meteo" | "google";
-export type WeatherProvider = ActualWeatherProvider;
+export type ActualWeatherProvider =
+	| "open-meteo"
+	| "google"
+	| "current-uv-index";
+export type WeatherProvider = "open-meteo" | "google";
 
 export interface WeatherData {
 	provider?: ActualWeatherProvider;

--- a/src/types.ts
+++ b/src/types.ts
@@ -141,6 +141,74 @@ export const SWEAT_CONFIG: Record<
 
 export const DEFAULT_SWEAT_LEVEL = SweatLevel.LOW;
 
+// Display units
+export const UnitSystem = {
+	IMPERIAL: "imperial",
+	METRIC: "metric",
+} as const;
+
+export type UnitSystem = (typeof UnitSystem)[keyof typeof UnitSystem];
+
+export const DEFAULT_UNIT_SYSTEM = UnitSystem.IMPERIAL;
+
+// Exposure planning
+export const StartTimeMode = {
+	NOW: "now",
+	PLANNED: "planned",
+} as const;
+
+export type StartTimeMode = (typeof StartTimeMode)[keyof typeof StartTimeMode];
+
+export const DEFAULT_START_TIME_MODE = StartTimeMode.NOW;
+
+export const ExposureGoal = {
+	AVOID_CHANGE: "avoid_change",
+	LIGHT_COLOR: "light_color",
+	MORE_COLOR: "more_color",
+} as const;
+
+export type ExposureGoal = (typeof ExposureGoal)[keyof typeof ExposureGoal];
+
+export const DEFAULT_EXPOSURE_GOAL = ExposureGoal.AVOID_CHANGE;
+export const DEFAULT_PLANNED_DURATION_MINUTES = 60;
+
+export const EXPOSURE_GOAL_CONFIG: Record<
+	ExposureGoal,
+	{
+		label: string;
+		shortLabel: string;
+		description: string;
+		minDamage: number;
+		targetDamage: number;
+		maxDamage: number;
+	}
+> = {
+	[ExposureGoal.AVOID_CHANGE]: {
+		label: "Avoid visible change",
+		shortLabel: "Zero tan",
+		description: "Keep the UV dose as low as practical.",
+		minDamage: 0,
+		targetDamage: 5,
+		maxDamage: 10,
+	},
+	[ExposureGoal.LIGHT_COLOR]: {
+		label: "Light color",
+		shortLabel: "Light tan",
+		description: "Aim for a small dose without getting close to burning.",
+		minDamage: 15,
+		targetDamage: 25,
+		maxDamage: 35,
+	},
+	[ExposureGoal.MORE_COLOR]: {
+		label: "More color",
+		shortLabel: "More tan",
+		description: "Allow more UV dose, still below the burn line.",
+		minDamage: 35,
+		targetDamage: 45,
+		maxDamage: 60,
+	},
+};
+
 // Weather Data
 export interface WeatherOverview {
 	id: number;
@@ -167,7 +235,11 @@ export interface AQIData {
 	us_aqi: number;
 }
 
+export type ActualWeatherProvider = "open-meteo" | "google";
+export type WeatherProvider = ActualWeatherProvider;
+
 export interface WeatherData {
+	provider?: ActualWeatherProvider;
 	current: CurrentWeather;
 	hourly: HourlyWeather[];
 	elevation: number; // meters above sea level
@@ -228,11 +300,38 @@ export interface CalculationResult {
 	advice: string[];
 }
 
+export interface ExposureDamageEstimate {
+	damage: number;
+	coveredMinutes: number;
+	forecastComplete: boolean;
+}
+
+export interface SPFRecommendationOption {
+	level: SPFLevel;
+	damage: number;
+}
+
+export interface SPFRecommendation {
+	level: SPFLevel;
+	status: "fits_goal" | "below_goal" | "too_risky";
+	damage: number;
+	goal: ExposureGoal;
+	durationMinutes: number;
+	options: SPFRecommendationOption[];
+	forecastComplete: boolean;
+}
+
 // App State
 export interface AppState {
 	skinType?: FitzpatrickType;
 	spfLevel?: SPFLevel;
 	sweatLevel?: SweatLevel;
+	unitSystem: UnitSystem;
+	startTimeMode: StartTimeMode;
+	plannedStartTime?: string;
+	plannedDurationMinutes: number;
+	exposureGoal: ExposureGoal;
+	weatherProvider?: WeatherProvider;
 	geolocation: GeolocationState;
 	calculation?: CalculationResult;
 }

--- a/src/utils/timezone.test.ts
+++ b/src/utils/timezone.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "bun:test";
 import {
 	formatInTimeZone,
+	getDayBoundsInTimeZone,
 	getHoursInTimezone,
 	getFractionalHoursInTimezone,
 } from "./timezone";
@@ -60,6 +61,22 @@ describe("Timezone Utilities", () => {
 			const tokyoResult = formatInTimeZone(utcDate, "Asia/Tokyo", "h:mm a");
 			expect(utcResult).toBe("6:30 PM");
 			expect(tokyoResult).toBe("3:30 AM");
+		});
+	});
+
+	describe("getDayBoundsInTimeZone", () => {
+		it("returns local day bounds for the selected timezone", () => {
+			const result = getDayBoundsInTimeZone(
+				new Date("2026-06-15T18:30:00Z"),
+				"America/Denver",
+			);
+
+			expect(result.start.getTime()).toBe(
+				new Date("2026-06-15T06:00:00.000Z").getTime(),
+			);
+			expect(result.end.getTime()).toBe(
+				new Date("2026-06-16T05:59:59.000Z").getTime(),
+			);
 		});
 	});
 });

--- a/src/utils/timezone.ts
+++ b/src/utils/timezone.ts
@@ -39,3 +39,71 @@ export function getFractionalHoursInTimezone(
 	const tzDate = toTZDate(date, timezone);
 	return tzDate.getHours() + tzDate.getMinutes() / 60;
 }
+
+function padDatePart(value: number): string {
+	return value.toString().padStart(2, "0");
+}
+
+/**
+ * Format a Date for an input[type="datetime-local"] in the selected place's timezone.
+ */
+export function formatDateTimeLocal(date: Date, timezone?: string): string {
+	const displayDate = toTZDate(date, timezone);
+	const year = displayDate.getFullYear();
+	const month = padDatePart(displayDate.getMonth() + 1);
+	const day = padDatePart(displayDate.getDate());
+	const hours = padDatePart(displayDate.getHours());
+	const minutes = padDatePart(displayDate.getMinutes());
+
+	return `${year}-${month}-${day}T${hours}:${minutes}`;
+}
+
+/**
+ * Parse a datetime-local value as local wall time in the selected place.
+ */
+export function parseDateTimeLocal(
+	value: string,
+	timezone?: string,
+): Date | null {
+	const [datePart, timePart] = value.split("T");
+	if (!datePart || !timePart) return null;
+
+	const [year, month, day] = datePart.split("-").map(Number);
+	const [hours, minutes] = timePart.split(":").map(Number);
+	const hasValidParts = [year, month, day, hours, minutes].every(
+		Number.isFinite,
+	);
+
+	if (!hasValidParts) return null;
+
+	if (timezone) {
+		return new TZDate(year, month - 1, day, hours, minutes, 0, timezone);
+	}
+
+	return new Date(year, month - 1, day, hours, minutes, 0);
+}
+
+/**
+ * Get the local calendar-day bounds for a Date in the selected place.
+ */
+export function getDayBoundsInTimeZone(
+	date: Date,
+	timezone?: string,
+): { start: Date; end: Date } {
+	const displayDate = toTZDate(date, timezone);
+	const year = displayDate.getFullYear();
+	const month = displayDate.getMonth();
+	const day = displayDate.getDate();
+
+	if (timezone) {
+		return {
+			start: new TZDate(year, month, day, 0, 0, 0, timezone),
+			end: new TZDate(year, month, day, 23, 59, 59, timezone),
+		};
+	}
+
+	return {
+		start: new Date(year, month, day, 0, 0, 0),
+		end: new Date(year, month, day, 23, 59, 59),
+	};
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -2,7 +2,7 @@
 	"compilerOptions": {
 		"tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
 		"target": "ES2023",
-		"lib": ["ES2023"],
+		"lib": ["ES2023", "DOM"],
 		"module": "ESNext",
 		"skipLibCheck": true,
 
@@ -21,5 +21,5 @@
 		"noFallthroughCasesInSwitch": true,
 		"noUncheckedSideEffectImports": true
 	},
-	"include": ["vite.config.ts"]
+	"include": ["vite.config.ts", "api/**/*.ts"]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+	"rewrites": [{ "source": "/google", "destination": "/index.html" }]
+}


### PR DESCRIPTION
## Summary
- Add a compact planning panel with start time, activity duration, unit switching, exposure goals, and SPF recommendations.
- Improve UV risk estimates with observed-current-UV anchoring, slow UVB recovery, sweat-aware SPF wear-off, and focused activity/day UV chart views.
- Route default weather lookup through a same-origin Vercel function, with CurrentUVIndex + MET Norway fallback when Open-Meteo is unavailable.
- Add an optional Google Weather preview provider behind `/google` while keeping Open-Meteo as the default provider.
- Refresh attribution and documentation, including clearer estimate caveats and source links.

## Deployment
- Vercel app for review: https://sunburntimer-taupe.vercel.app
- The upstream repository appears stale, so this deployment is available while the pull request is pending.

## Verification
- `bun run check`
- `bun test`
- `bun run build`
- Production API check for `/api/open-meteo-weather` returning 200 while Open-Meteo returns upstream errors.
- Browser check on production for the current-location button with controlled GPS coordinates, including network requests and console output.
- Browser check on desktop and mobile widths for planner, UV chart modes, footer attribution, `/google` provider switch, and horizontal overflow.