### PR TITLE
Handle missing Open-Meteo UV forecasts

### DIFF
--- a/src/services/weather.test.ts
+++ b/src/services/weather.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { fetchWeatherData } from "./weather";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+	globalThis.fetch = originalFetch;
+});
+
+function createForecastResponse(
+	uvIndex: Array<number | null>,
+	currentUvIndex: number | null = null,
+) {
+	return {
+		elevation: 160,
+		timezone: "America/Chicago",
+		current: {
+			time: "2026-05-26T10:45",
+			temperature_2m: 75.9,
+			uv_index: currentUvIndex,
+			weather_code: 3,
+		},
+		hourly: {
+			time: ["2026-05-26T10:00", "2026-05-26T11:00", "2026-05-26T12:00"],
+			temperature_2m: [75, 77, 80],
+			uv_index: uvIndex,
+			weather_code: [3, 3, 2],
+		},
+		daily: {
+			sunrise: ["2026-05-26T06:31", "2026-05-27T06:31"],
+			sunset: ["2026-05-26T20:24", "2026-05-27T20:25"],
+		},
+	};
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+	return new Response(JSON.stringify(body), {
+		status,
+		statusText: status === 200 ? "OK" : "Error",
+	});
+}
+
+function getFetchUrl(input: Parameters<typeof fetch>[0]): string {
+	if (typeof input === "string") return input;
+	if (input instanceof URL) return input.toString();
+
+	return input.url;
+}
+
+describe("fetchWeatherData", () => {
+	it("throws a recoverable error when Open-Meteo returns no usable UV forecast", async () => {
+		globalThis.fetch = async () =>
+			jsonResponse(createForecastResponse([null, null, null]));
+
+		await expect(
+			fetchWeatherData({ latitude: 30.2672, longitude: -97.7431 }),
+		).rejects.toThrow("UV forecast is currently unavailable");
+	});
+
+	it("throws a recoverable error when Open-Meteo returns a partial UV forecast", async () => {
+		globalThis.fetch = async () =>
+			jsonResponse(createForecastResponse([0.8, 4.5, null], 0.8));
+
+		await expect(
+			fetchWeatherData({ latitude: 30.2672, longitude: -97.7431 }),
+		).rejects.toThrow("UV forecast is currently unavailable");
+	});
+
+	it("throws a recoverable error when hourly UV values are unavailable", async () => {
+		globalThis.fetch = async () =>
+			jsonResponse(createForecastResponse([null, null, null], 0.8));
+
+		await expect(
+			fetchWeatherData({ latitude: 30.2672, longitude: -97.7431 }),
+		).rejects.toThrow("UV forecast is currently unavailable");
+	});
+
+	it("returns weather when Open-Meteo returns a complete UV forecast", async () => {
+		globalThis.fetch = async (input) => {
+			if (getFetchUrl(input).includes("air-quality")) {
+				return jsonResponse({ current: { us_aqi: 42 } });
+			}
+
+			return jsonResponse(createForecastResponse([0.8, 4.5, 6.2], 0.8));
+		};
+
+		const weather = await fetchWeatherData({
+			latitude: 30.2672,
+			longitude: -97.7431,
+		});
+
+		expect(weather.current.uvi).toBe(0.8);
+		expect(weather.hourly.map((hour) => hour.uvi)).toEqual([0.8, 4.5, 6.2]);
+		expect(weather.aqi?.us_aqi).toBe(42);
+	});
+});

--- a/src/services/weather.ts
+++ b/src/services/weather.ts
@@ -3,20 +3,23 @@ import type { Position, WeatherData, AQIData } from "../types";
 import { WMO_DESCRIPTIONS } from "../constants/wmo-descriptions";
 import { fetchAQIData } from "./aqi";
 
+const UV_FORECAST_UNAVAILABLE_ERROR =
+	"UV forecast is currently unavailable. Please try again later.";
+
 interface OpenMeteoResponse {
 	elevation: number;
 	timezone: string;
 	current: {
 		time: string;
 		temperature_2m: number;
-		uv_index: number;
-		weather_code: number;
+		uv_index: number | null;
+		weather_code: number | null;
 	};
 	hourly: {
 		time: string[];
 		temperature_2m: number[];
-		uv_index: number[];
-		weather_code: number[];
+		uv_index: (number | null)[];
+		weather_code: (number | null)[];
 	};
 	daily: {
 		sunrise: string[];
@@ -33,6 +36,36 @@ function parseLocationTime(timeStr: string, timezone: string): number {
 	const [y, m, d] = datePart.split("-").map(Number);
 	const [h, min] = (timePart ?? "00:00").split(":").map(Number);
 	return new TZDate(y, m - 1, d, h, min, 0, timezone).getTime();
+}
+
+function isFiniteNumber(value: unknown): value is number {
+	return typeof value === "number" && Number.isFinite(value);
+}
+
+function getWeatherDescription(code: number | null | undefined): string {
+	if (!isFiniteNumber(code)) return "Unknown";
+
+	return (
+		WMO_DESCRIPTIONS[
+			Math.trunc(code).toString() as keyof typeof WMO_DESCRIPTIONS
+		] || "Unknown"
+	);
+}
+
+function requireUvIndex(value: unknown): number {
+	if (!isFiniteNumber(value)) {
+		throw new Error(UV_FORECAST_UNAVAILABLE_ERROR);
+	}
+
+	return value;
+}
+
+function getHourlyUvIndex(hourly: OpenMeteoResponse["hourly"]): number[] {
+	if (hourly.time.length === 0 || hourly.uv_index.length < hourly.time.length) {
+		throw new Error(UV_FORECAST_UNAVAILABLE_ERROR);
+	}
+
+	return hourly.time.map((_, i) => requireUvIndex(hourly.uv_index[i]));
 }
 
 export async function fetchWeatherData(
@@ -70,26 +103,24 @@ export async function fetchWeatherData(
 	const data: OpenMeteoResponse = await response.json();
 
 	// Validate required fields
-	if (!data.current || !data.hourly) {
+	if (!data.current || !data.hourly || !data.daily) {
 		throw new Error("Invalid weather data received from API");
 	}
 
 	const locationTimezone = data.timezone;
+	const currentUv = requireUvIndex(data.current.uv_index);
 
 	const current = {
 		dt: Math.floor(
 			parseLocationTime(data.current.time, locationTimezone) / 1000,
 		),
 		temp: data.current.temperature_2m,
-		uvi: data.current.uv_index,
+		uvi: currentUv,
 		weather: [
 			{
 				id: 800,
 				main: "Clear",
-				description:
-					WMO_DESCRIPTIONS[
-						data.current.weather_code.toString() as keyof typeof WMO_DESCRIPTIONS
-					] || "Unknown",
+				description: getWeatherDescription(data.current.weather_code),
 				icon: "01d",
 			},
 		],
@@ -98,27 +129,25 @@ export async function fetchWeatherData(
 	// Convert hourly data (use all available data from 3-day forecast)
 	const hourlyData = data.hourly;
 	const maxHours = hourlyData.time.length;
+	const hourlyUvIndex = getHourlyUvIndex(hourlyData);
 
-	const hourly = Array.from({ length: maxHours }, (_, i) => ({
-		dt: Math.floor(
-			parseLocationTime(hourlyData.time[i], locationTimezone) / 1000,
-		),
-		temp: hourlyData.temperature_2m[i],
-		uvi: hourlyData.uv_index[i],
-		weather: [
-			{
-				id: 800,
-				main: "Clear",
-				description:
-					WMO_DESCRIPTIONS[
-						hourlyData.weather_code[
-							i
-						].toString() as keyof typeof WMO_DESCRIPTIONS
-					] || "Unknown",
-				icon: "01d",
-			},
-		],
-	}));
+	const hourly = Array.from({ length: maxHours }, (_, i) => {
+		return {
+			dt: Math.floor(
+				parseLocationTime(hourlyData.time[i], locationTimezone) / 1000,
+			),
+			temp: hourlyData.temperature_2m[i],
+			uvi: hourlyUvIndex[i],
+			weather: [
+				{
+					id: 800,
+					main: "Clear",
+					description: getWeatherDescription(hourlyData.weather_code[i]),
+					icon: "01d",
+				},
+			],
+		};
+	});
 
 	// Fetch AQI data
 	let aqi: AQIData | undefined;


### PR DESCRIPTION
## Summary
- reject Open-Meteo responses when the current or hourly UV forecast contains missing/non-finite values
- tolerate missing WMO weather codes without throwing while preserving complete UV requirements
- add weather service regression tests for all-null, partial-null, and complete UV forecast payloads

## Validation
- sub-agent review completed; initial findings were addressed and final focused review reported no remaining issues
- /Users/jon/.bun/bin/bun --bun run check
- /Users/jon/.bun/bin/bun --bun test
- /Users/jon/.bun/bin/bun --bun run build

## Notes
- Current behavior intentionally fails weather loading for incomplete upstream UV forecasts instead of treating unknown UV as zero, to avoid understating sunburn risk.