### PR TITLE
Add Google weather fallback provider

### DIFF
--- a/api/google-weather.test.ts
+++ b/api/google-weather.test.ts
@@ -1,0 +1,480 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import {
+	GET as handler,
+	resetGoogleWeatherRateLimitForTests,
+} from "./google-weather";
+
+const originalFetch = globalThis.fetch;
+const originalApiKey = process.env.GOOGLE_MAPS_API_KEY;
+
+afterEach(() => {
+	globalThis.fetch = originalFetch;
+	resetGoogleWeatherRateLimitForTests();
+	if (originalApiKey === undefined) {
+		delete process.env.GOOGLE_MAPS_API_KEY;
+	} else {
+		process.env.GOOGLE_MAPS_API_KEY = originalApiKey;
+	}
+});
+
+function createRequest(path: string): Request {
+	return new Request(`https://sunburntimer.test${path}`);
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+	return new Response(JSON.stringify(body), {
+		status,
+		statusText: status === 200 ? "OK" : "Error",
+		headers: {
+			"Content-Type": "application/json",
+		},
+	});
+}
+
+function getFetchUrl(input: Parameters<typeof fetch>[0]): string {
+	if (typeof input === "string") return input;
+	if (input instanceof URL) return input.toString();
+
+	return input.url;
+}
+
+describe("/api/google-weather", () => {
+	it("rejects unsupported methods", async () => {
+		const response = await handler(
+			new Request("https://sunburntimer.test/api/google-weather", {
+				method: "POST",
+			}),
+		);
+
+		expect(response.status).toBe(405);
+		expect(await response.json()).toEqual({ error: "Method not allowed" });
+	});
+
+	it("returns a configuration error when the Google key is missing", async () => {
+		delete process.env.GOOGLE_MAPS_API_KEY;
+
+		const response = await handler(
+			createRequest("/api/google-weather?latitude=30.2672&longitude=-97.7431"),
+		);
+
+		expect(response.status).toBe(500);
+		expect(await response.json()).toEqual({
+			error: "Missing GOOGLE_MAPS_API_KEY",
+		});
+	});
+
+	it("rejects invalid coordinates", async () => {
+		process.env.GOOGLE_MAPS_API_KEY = "test-key";
+
+		const response = await handler(
+			createRequest("/api/google-weather?latitude=500&longitude=-97"),
+		);
+
+		expect(response.status).toBe(400);
+		expect(await response.json()).toEqual({
+			error: "Valid latitude and longitude are required",
+		});
+	});
+
+	it("normalizes Google weather responses to WeatherData", async () => {
+		process.env.GOOGLE_MAPS_API_KEY = "test-key";
+		globalThis.fetch = async (input) => {
+			const url = getFetchUrl(input);
+
+			if (url.includes("forecast/hours")) {
+				return jsonResponse({
+					forecastHours: [
+						{
+							interval: { startTime: "2026-05-26T16:00:00Z" },
+							temperature: { degrees: 76.4 },
+							uvIndex: 4,
+							weatherCondition: {
+								iconBaseUri: "https://maps.gstatic.com/weather/v1/sunny",
+								type: "CLEAR",
+								description: { text: "Sunny" },
+							},
+						},
+						{
+							interval: { startTime: "2026-05-26T17:00:00Z" },
+							temperature: { degrees: 78.1 },
+							uvIndex: 5,
+							weatherCondition: {
+								type: "PARTLY_CLOUDY",
+								description: { text: "Partly cloudy" },
+							},
+						},
+					],
+					timeZone: { id: "America/Chicago" },
+				});
+			}
+
+			if (url.includes("forecast/days")) {
+				return jsonResponse({
+					forecastDays: [
+						{
+							sunEvents: {
+								sunriseTime: "2026-05-26T11:31:00Z",
+								sunsetTime: "2026-05-27T01:24:00Z",
+							},
+						},
+						{
+							sunEvents: {
+								sunriseTime: "2026-05-27T11:31:00Z",
+								sunsetTime: "2026-05-28T01:25:00Z",
+							},
+						},
+					],
+					timeZone: { id: "America/Chicago" },
+				});
+			}
+
+			return jsonResponse({
+				results: [{ elevation: 160.3 }],
+				status: "OK",
+			});
+		};
+
+		const response = await handler(
+			createRequest("/api/google-weather?latitude=30.2672&longitude=-97.7431"),
+		);
+		const body = await response.json();
+
+		expect(response.status).toBe(200);
+		expect(response.headers.get("X-Weather-Provider")).toBe("google");
+		expect(body.current.weather[0].id).toBe(0);
+		expect(body.current.uvi).toBe(4);
+		expect(body.hourly.map((hour: { uvi: number }) => hour.uvi)).toEqual([
+			4, 5,
+		]);
+		expect(body.elevation).toBe(160.3);
+		expect(body.sunrise).toBe("2026-05-26T11:31:00Z");
+		expect(body.timezone).toBe("America/Chicago");
+	});
+
+	it("fetches paginated hourly weather responses", async () => {
+		process.env.GOOGLE_MAPS_API_KEY = "test-key";
+		globalThis.fetch = async (input) => {
+			const url = getFetchUrl(input);
+
+			if (url.includes("forecast/hours")) {
+				if (url.includes("pageToken=next-page")) {
+					return jsonResponse({
+						forecastHours: [
+							{
+								interval: { startTime: "2026-05-26T17:00:00Z" },
+								temperature: { degrees: 78.1 },
+								uvIndex: 5,
+							},
+						],
+						timeZone: { id: "America/Chicago" },
+					});
+				}
+
+				return jsonResponse({
+					forecastHours: [
+						{
+							interval: { startTime: "2026-05-26T16:00:00Z" },
+							temperature: { degrees: 76.4 },
+							uvIndex: 4,
+						},
+					],
+					timeZone: { id: "America/Chicago" },
+					nextPageToken: "next-page",
+				});
+			}
+
+			if (url.includes("forecast/days")) {
+				return jsonResponse({
+					forecastDays: [
+						{
+							sunEvents: {
+								sunriseTime: "2026-05-26T11:31:00Z",
+								sunsetTime: "2026-05-27T01:24:00Z",
+							},
+						},
+						{
+							sunEvents: {
+								sunriseTime: "2026-05-27T11:31:00Z",
+							},
+						},
+					],
+					timeZone: { id: "America/Chicago" },
+				});
+			}
+
+			return jsonResponse({
+				results: [{ elevation: 160.3 }],
+				status: "OK",
+			});
+		};
+
+		const response = await handler(
+			createRequest("/api/google-weather?latitude=30.2672&longitude=-97.7431"),
+		);
+		const body = await response.json();
+
+		expect(response.status).toBe(200);
+		expect(body.hourly.map((hour: { uvi: number }) => hour.uvi)).toEqual([
+			4, 5,
+		]);
+	});
+
+	it("returns a provider error when Google sun events are missing", async () => {
+		process.env.GOOGLE_MAPS_API_KEY = "test-key";
+		globalThis.fetch = async (input) => {
+			const url = getFetchUrl(input);
+
+			if (url.includes("forecast/hours")) {
+				return jsonResponse({
+					forecastHours: [
+						{
+							interval: { startTime: "2026-05-26T16:00:00Z" },
+							temperature: { degrees: 76.4 },
+							uvIndex: 4,
+						},
+					],
+					timeZone: { id: "America/Chicago" },
+				});
+			}
+
+			if (url.includes("forecast/days")) {
+				return jsonResponse({
+					forecastDays: [{ sunEvents: {} }],
+					timeZone: { id: "America/Chicago" },
+				});
+			}
+
+			return jsonResponse({
+				results: [{ elevation: 160.3 }],
+				status: "OK",
+			});
+		};
+
+		const response = await handler(
+			createRequest("/api/google-weather?latitude=30.2672&longitude=-97.7431"),
+		);
+
+		expect(response.status).toBe(502);
+		expect(await response.json()).toEqual({
+			error: "Missing Google sunrise forecast",
+		});
+	});
+
+	it("returns a provider error when Google next sunrise is missing", async () => {
+		process.env.GOOGLE_MAPS_API_KEY = "test-key";
+		globalThis.fetch = async (input) => {
+			const url = getFetchUrl(input);
+
+			if (url.includes("forecast/hours")) {
+				return jsonResponse({
+					forecastHours: [
+						{
+							interval: { startTime: "2026-05-26T16:00:00Z" },
+							temperature: { degrees: 76.4 },
+							uvIndex: 4,
+						},
+					],
+					timeZone: { id: "America/Chicago" },
+				});
+			}
+
+			if (url.includes("forecast/days")) {
+				return jsonResponse({
+					forecastDays: [
+						{
+							sunEvents: {
+								sunriseTime: "2026-05-26T11:31:00Z",
+								sunsetTime: "2026-05-27T01:24:00Z",
+							},
+						},
+					],
+					timeZone: { id: "America/Chicago" },
+				});
+			}
+
+			return jsonResponse({
+				results: [{ elevation: 160.3 }],
+				status: "OK",
+			});
+		};
+
+		const response = await handler(
+			createRequest("/api/google-weather?latitude=30.2672&longitude=-97.7431"),
+		);
+
+		expect(response.status).toBe(502);
+		expect(await response.json()).toEqual({
+			error: "Missing Google next sunrise forecast",
+		});
+	});
+
+	it("returns a provider error when Google hourly weather is empty", async () => {
+		process.env.GOOGLE_MAPS_API_KEY = "test-key";
+		globalThis.fetch = async (input) => {
+			const url = getFetchUrl(input);
+
+			if (url.includes("forecast/hours")) {
+				return jsonResponse({
+					forecastHours: [],
+					timeZone: { id: "America/Chicago" },
+				});
+			}
+
+			if (url.includes("forecast/days")) {
+				return jsonResponse({
+					forecastDays: [
+						{
+							sunEvents: {
+								sunriseTime: "2026-05-26T11:31:00Z",
+								sunsetTime: "2026-05-27T01:24:00Z",
+							},
+						},
+						{
+							sunEvents: {
+								sunriseTime: "2026-05-27T11:31:00Z",
+							},
+						},
+					],
+					timeZone: { id: "America/Chicago" },
+				});
+			}
+
+			return jsonResponse({
+				results: [{ elevation: 160.3 }],
+				status: "OK",
+			});
+		};
+
+		const response = await handler(
+			createRequest("/api/google-weather?latitude=30.2672&longitude=-97.7431"),
+		);
+
+		expect(response.status).toBe(502);
+		expect(await response.json()).toEqual({
+			error: "Empty Google hourly weather response",
+		});
+	});
+
+	it("falls back to zero elevation when Google Elevation is unavailable", async () => {
+		process.env.GOOGLE_MAPS_API_KEY = "test-key";
+		globalThis.fetch = async (input) => {
+			const url = getFetchUrl(input);
+
+			if (url.includes("forecast/hours")) {
+				return jsonResponse({
+					forecastHours: [
+						{
+							interval: { startTime: "2026-05-26T16:00:00Z" },
+							temperature: { degrees: 76.4 },
+							uvIndex: 4,
+						},
+					],
+					timeZone: { id: "America/Chicago" },
+				});
+			}
+
+			if (url.includes("forecast/days")) {
+				return jsonResponse({
+					forecastDays: [
+						{
+							sunEvents: {
+								sunriseTime: "2026-05-26T11:31:00Z",
+								sunsetTime: "2026-05-27T01:24:00Z",
+							},
+						},
+						{
+							sunEvents: {
+								sunriseTime: "2026-05-27T11:31:00Z",
+							},
+						},
+					],
+					timeZone: { id: "America/Chicago" },
+				});
+			}
+
+			return jsonResponse({ error: "Elevation API disabled" }, 403);
+		};
+
+		const response = await handler(
+			createRequest("/api/google-weather?latitude=30.2672&longitude=-97.7431"),
+		);
+		const body = await response.json();
+
+		expect(response.status).toBe(200);
+		expect(body.elevation).toBe(0);
+	});
+
+	it("returns a provider error when an hourly UV value is missing", async () => {
+		process.env.GOOGLE_MAPS_API_KEY = "test-key";
+		globalThis.fetch = async (input) => {
+			const url = getFetchUrl(input);
+
+			if (url.includes("forecast/hours")) {
+				return jsonResponse({
+					forecastHours: [
+						{
+							interval: { startTime: "2026-05-26T16:00:00Z" },
+							temperature: { degrees: 76.4 },
+						},
+					],
+					timeZone: { id: "America/Chicago" },
+				});
+			}
+
+			if (url.includes("forecast/days")) {
+				return jsonResponse({
+					forecastDays: [
+						{
+							sunEvents: {
+								sunriseTime: "2026-05-26T11:31:00Z",
+								sunsetTime: "2026-05-27T01:24:00Z",
+							},
+						},
+						{
+							sunEvents: {
+								sunriseTime: "2026-05-27T11:31:00Z",
+							},
+						},
+					],
+					timeZone: { id: "America/Chicago" },
+				});
+			}
+
+			return jsonResponse({
+				results: [{ elevation: 160.3 }],
+				status: "OK",
+			});
+		};
+
+		const response = await handler(
+			createRequest("/api/google-weather?latitude=30.2672&longitude=-97.7431"),
+		);
+
+		expect(response.status).toBe(502);
+		expect(await response.json()).toEqual({
+			error: "Invalid Google hourly weather response",
+		});
+	});
+
+	it("rate limits repeated requests from the same forwarded IP", async () => {
+		delete process.env.GOOGLE_MAPS_API_KEY;
+		const request = new Request(
+			"https://sunburntimer.test/api/google-weather?latitude=30.2672&longitude=-97.7431",
+			{
+				headers: {
+					"x-forwarded-for": "203.0.113.10",
+				},
+			},
+		);
+		let response = new Response(null);
+
+		for (let i = 0; i < 121; i++) {
+			response = await handler(request);
+		}
+
+		expect(response.status).toBe(429);
+		expect(await response.json()).toEqual({
+			error: "Too many Google weather requests. Please try again later.",
+		});
+	});
+});

--- a/api/google-weather.ts
+++ b/api/google-weather.ts
@@ -1,0 +1,482 @@
+type WeatherOverview = {
+	id: number;
+	main: string;
+	description: string;
+	icon: string;
+};
+
+type WeatherData = {
+	current: {
+		dt: number;
+		temp: number;
+		uvi: number;
+		weather: WeatherOverview[];
+	};
+	hourly: Array<{
+		dt: number;
+		temp: number;
+		uvi: number;
+		weather: WeatherOverview[];
+	}>;
+	elevation: number;
+	sunrise: string;
+	sunset: string;
+	nextSunrise: string;
+	timezone: string;
+};
+
+type GoogleForecastHour = {
+	interval?: {
+		startTime?: string;
+	};
+	weatherCondition?: GoogleWeatherCondition;
+	temperature?: {
+		degrees?: number;
+	};
+	uvIndex?: number;
+};
+
+type GoogleForecastDay = {
+	sunEvents?: {
+		sunriseTime?: string;
+		sunsetTime?: string;
+	};
+};
+
+type GoogleWeatherCondition = {
+	iconBaseUri?: string;
+	type?: string;
+	description?: {
+		text?: string;
+	};
+};
+
+type GoogleHourlyResponse = {
+	forecastHours?: GoogleForecastHour[];
+	timeZone?: {
+		id?: string;
+	};
+	nextPageToken?: string;
+};
+
+type GoogleDailyResponse = {
+	forecastDays?: GoogleForecastDay[];
+	timeZone?: {
+		id?: string;
+	};
+};
+
+type GoogleElevationResponse = {
+	results?: Array<{
+		elevation?: number;
+	}>;
+	status?: string;
+	error_message?: string;
+};
+
+const GOOGLE_WEATHER_HOURLY_URL =
+	"https://weather.googleapis.com/v1/forecast/hours:lookup";
+const GOOGLE_WEATHER_DAILY_URL =
+	"https://weather.googleapis.com/v1/forecast/days:lookup";
+const GOOGLE_ELEVATION_URL =
+	"https://maps.googleapis.com/maps/api/elevation/json";
+const FORECAST_HOURS = 72;
+const DAILY_FORECAST_DAYS = 2;
+const MAX_GOOGLE_FORECAST_PAGES = 5;
+const RATE_LIMIT_WINDOW_MS = 60 * 60 * 1000;
+const RATE_LIMIT_MAX = 120;
+const RATE_LIMIT_MAX_ENTRIES = 1000;
+const RATE_LIMIT_PRUNE_INTERVAL = 100;
+const NEUTRAL_WEATHER_CODE = 0;
+
+type RateLimitEntry = {
+	windowStart: number;
+	count: number;
+};
+
+const globalRuntime = globalThis as typeof globalThis & {
+	__sunburnGoogleWeatherRateLimit?: Map<string, RateLimitEntry>;
+};
+
+// Best-effort quota protection for this Vercel function instance. This is not
+// a distributed rate limit; Google Cloud quotas remain the final backstop.
+const rateLimit =
+	globalRuntime.__sunburnGoogleWeatherRateLimit ??
+	new Map<string, RateLimitEntry>();
+let rateLimitRequestCount = 0;
+
+globalRuntime.__sunburnGoogleWeatherRateLimit = rateLimit;
+
+export async function GET(request: Request): Promise<Response> {
+	if (request.method !== "GET") {
+		return jsonResponse({ error: "Method not allowed" }, 405);
+	}
+
+	const rateLimitResponse = checkRateLimit(request);
+	if (rateLimitResponse) {
+		return rateLimitResponse;
+	}
+
+	const apiKey = process.env.GOOGLE_MAPS_API_KEY;
+	if (!apiKey) {
+		return jsonResponse({ error: "Missing GOOGLE_MAPS_API_KEY" }, 500);
+	}
+
+	const url = new URL(request.url);
+	const latitude = parseCoordinate(url.searchParams.get("latitude"), -90, 90);
+	const longitude = parseCoordinate(
+		url.searchParams.get("longitude"),
+		-180,
+		180,
+	);
+
+	if (latitude === undefined || longitude === undefined) {
+		return jsonResponse(
+			{ error: "Valid latitude and longitude are required" },
+			400,
+		);
+	}
+
+	try {
+		const [hourly, daily, elevation] = await Promise.all([
+			fetchGoogleHourlyWeather(apiKey, latitude, longitude),
+			fetchGoogleDailyWeather(apiKey, latitude, longitude),
+			fetchGoogleElevation(apiKey, latitude, longitude).catch(() => 0),
+		]);
+
+		return jsonResponse(normalizeWeatherData(hourly, daily, elevation), 200, {
+			"Cache-Control": "no-store",
+			"X-Weather-Provider": "google",
+		});
+	} catch (error) {
+		return jsonResponse(
+			{
+				error:
+					error instanceof Error
+						? error.message
+						: "Failed to fetch Google weather",
+			},
+			502,
+		);
+	}
+}
+
+export default {
+	fetch: GET,
+};
+
+function parseCoordinate(
+	value: string | null,
+	min: number,
+	max: number,
+): number | undefined {
+	if (!value) {
+		return undefined;
+	}
+
+	const coordinate = Number(value);
+	if (!Number.isFinite(coordinate) || coordinate < min || coordinate > max) {
+		return undefined;
+	}
+
+	return coordinate;
+}
+
+async function fetchGoogleHourlyWeather(
+	apiKey: string,
+	latitude: number,
+	longitude: number,
+): Promise<GoogleHourlyResponse> {
+	let nextPageToken: string | undefined;
+	let timeZone: GoogleHourlyResponse["timeZone"];
+	const forecastHours: GoogleForecastHour[] = [];
+	let pageCount = 0;
+
+	do {
+		pageCount += 1;
+		const page = await fetchGoogleHourlyWeatherPage(
+			apiKey,
+			latitude,
+			longitude,
+			nextPageToken,
+		);
+		timeZone ??= page.timeZone;
+		forecastHours.push(...(page.forecastHours ?? []));
+		nextPageToken = page.nextPageToken;
+	} while (
+		nextPageToken &&
+		forecastHours.length < FORECAST_HOURS &&
+		pageCount < MAX_GOOGLE_FORECAST_PAGES
+	);
+
+	return {
+		forecastHours: forecastHours.slice(0, FORECAST_HOURS),
+		timeZone,
+	};
+}
+
+async function fetchGoogleHourlyWeatherPage(
+	apiKey: string,
+	latitude: number,
+	longitude: number,
+	pageToken?: string,
+): Promise<GoogleHourlyResponse> {
+	const url = new URL(GOOGLE_WEATHER_HOURLY_URL);
+	const params = new URLSearchParams({
+		key: apiKey,
+		"location.latitude": latitude.toString(),
+		"location.longitude": longitude.toString(),
+		unitsSystem: "IMPERIAL",
+		hours: FORECAST_HOURS.toString(),
+		pageSize: "24",
+		languageCode: "en",
+	});
+
+	if (pageToken) {
+		params.set("pageToken", pageToken);
+	}
+
+	url.search = params.toString();
+
+	const response = await fetch(url);
+	if (!response.ok) {
+		throw new Error(
+			`Google hourly weather error: ${response.status} ${response.statusText}`,
+		);
+	}
+
+	return response.json();
+}
+
+async function fetchGoogleDailyWeather(
+	apiKey: string,
+	latitude: number,
+	longitude: number,
+): Promise<GoogleDailyResponse> {
+	const url = new URL(GOOGLE_WEATHER_DAILY_URL);
+	url.search = new URLSearchParams({
+		key: apiKey,
+		"location.latitude": latitude.toString(),
+		"location.longitude": longitude.toString(),
+		unitsSystem: "IMPERIAL",
+		days: DAILY_FORECAST_DAYS.toString(),
+		pageSize: DAILY_FORECAST_DAYS.toString(),
+		languageCode: "en",
+	}).toString();
+
+	const response = await fetch(url);
+	if (!response.ok) {
+		throw new Error(
+			`Google daily weather error: ${response.status} ${response.statusText}`,
+		);
+	}
+
+	return response.json();
+}
+
+async function fetchGoogleElevation(
+	apiKey: string,
+	latitude: number,
+	longitude: number,
+): Promise<number> {
+	const url = new URL(GOOGLE_ELEVATION_URL);
+	url.search = new URLSearchParams({
+		key: apiKey,
+		locations: `${latitude},${longitude}`,
+	}).toString();
+
+	const response = await fetch(url);
+	if (!response.ok) {
+		throw new Error(
+			`Google elevation error: ${response.status} ${response.statusText}`,
+		);
+	}
+
+	const data = (await response.json()) as GoogleElevationResponse;
+	const elevation = data.results?.[0]?.elevation;
+
+	if (data.status !== "OK" || typeof elevation !== "number") {
+		throw new Error(data.error_message || "Invalid Google elevation response");
+	}
+
+	return elevation;
+}
+
+function normalizeWeatherData(
+	hourlyResponse: GoogleHourlyResponse,
+	dailyResponse: GoogleDailyResponse,
+	elevation: number,
+): WeatherData {
+	const timezone = hourlyResponse.timeZone?.id || dailyResponse.timeZone?.id;
+	if (!timezone) {
+		throw new Error("Missing Google weather timezone");
+	}
+
+	const hourly = (hourlyResponse.forecastHours ?? []).map((hour) =>
+		normalizeHourlyWeather(hour),
+	);
+	const current = hourly[0];
+	if (!current) {
+		throw new Error("Empty Google hourly weather response");
+	}
+
+	const today = dailyResponse.forecastDays?.[0]?.sunEvents;
+	const tomorrow = dailyResponse.forecastDays?.[1]?.sunEvents;
+	const sunrise = today?.sunriseTime;
+	const sunset = today?.sunsetTime;
+	const nextSunrise = tomorrow?.sunriseTime;
+	if (!sunrise) {
+		throw new Error("Missing Google sunrise forecast");
+	}
+	if (!sunset) {
+		throw new Error("Missing Google sunset forecast");
+	}
+	if (!nextSunrise) {
+		throw new Error("Missing Google next sunrise forecast");
+	}
+
+	return {
+		current,
+		hourly,
+		elevation,
+		sunrise,
+		sunset,
+		nextSunrise,
+		timezone,
+	};
+}
+
+function normalizeHourlyWeather(
+	hour: GoogleForecastHour,
+): WeatherData["hourly"][number] {
+	const startTime = hour.interval?.startTime;
+	const temperature = hour.temperature?.degrees;
+	const uvIndex = hour.uvIndex;
+
+	if (
+		!startTime ||
+		typeof temperature !== "number" ||
+		typeof uvIndex !== "number"
+	) {
+		throw new Error("Invalid Google hourly weather response");
+	}
+
+	return {
+		dt: Math.floor(Date.parse(startTime) / 1000),
+		temp: temperature,
+		uvi: uvIndex,
+		weather: [normalizeWeatherOverview(hour.weatherCondition)],
+	};
+}
+
+function normalizeWeatherOverview(
+	condition: GoogleWeatherCondition | undefined,
+): WeatherOverview {
+	const type = condition?.type ?? "UNKNOWN";
+	const description =
+		condition?.description?.text ?? type.replaceAll("_", " ").toLowerCase();
+
+	return {
+		// The app currently renders Google condition text, not OpenWeather codes.
+		// Keep this sentinel neutral rather than pretending every condition is clear.
+		id: NEUTRAL_WEATHER_CODE,
+		main: toTitleCase(type.replaceAll("_", " ").toLowerCase()),
+		description,
+		icon: condition?.iconBaseUri ?? "",
+	};
+}
+
+function checkRateLimit(request: Request): Response | undefined {
+	const ipAddress = getIpAddress(request);
+	const now = Date.now();
+	rateLimitRequestCount = (rateLimitRequestCount + 1) % Number.MAX_SAFE_INTEGER;
+
+	if (
+		rateLimit.size >= RATE_LIMIT_MAX_ENTRIES ||
+		rateLimitRequestCount % RATE_LIMIT_PRUNE_INTERVAL === 0
+	) {
+		pruneExpiredRateLimitEntries(now);
+	}
+
+	const entry = rateLimit.get(ipAddress);
+
+	if (!entry || now - entry.windowStart >= RATE_LIMIT_WINDOW_MS) {
+		if (!entry && rateLimit.size >= RATE_LIMIT_MAX_ENTRIES) {
+			evictOldestRateLimitEntry();
+		}
+		rateLimit.set(ipAddress, { windowStart: now, count: 1 });
+		return undefined;
+	}
+
+	entry.count += 1;
+	if (entry.count <= RATE_LIMIT_MAX) {
+		return undefined;
+	}
+
+	return jsonResponse(
+		{ error: "Too many Google weather requests. Please try again later." },
+		429,
+		{
+			"Retry-After": Math.ceil(
+				(RATE_LIMIT_WINDOW_MS - (now - entry.windowStart)) / 1000,
+			).toString(),
+		},
+	);
+}
+
+export function resetGoogleWeatherRateLimitForTests(): void {
+	rateLimit.clear();
+	rateLimitRequestCount = 0;
+}
+
+function getIpAddress(request: Request): string {
+	// This endpoint is deployed behind Vercel, which supplies forwarding headers.
+	// Outside a trusted proxy, these headers should not be treated as authoritative.
+	return (
+		request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
+		request.headers.get("x-real-ip") ||
+		"unknown"
+	);
+}
+
+function pruneExpiredRateLimitEntries(now: number): void {
+	for (const [ipAddress, entry] of rateLimit) {
+		if (now - entry.windowStart >= RATE_LIMIT_WINDOW_MS) {
+			rateLimit.delete(ipAddress);
+		}
+	}
+}
+
+function evictOldestRateLimitEntry(): void {
+	let oldestIpAddress: string | undefined;
+	let oldestWindowStart = Infinity;
+
+	for (const [ipAddress, entry] of rateLimit) {
+		if (entry.windowStart < oldestWindowStart) {
+			oldestIpAddress = ipAddress;
+			oldestWindowStart = entry.windowStart;
+		}
+	}
+
+	if (oldestIpAddress) {
+		rateLimit.delete(oldestIpAddress);
+	}
+}
+
+function toTitleCase(value: string): string {
+	return value.replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+function jsonResponse(
+	body: unknown,
+	status: number,
+	headers?: Record<string, string>,
+): Response {
+	return Response.json(body, {
+		status,
+		headers: {
+			...headers,
+			"Content-Type": "application/json",
+		},
+	});
+}

--- a/src/services/weather.test.ts
+++ b/src/services/weather.test.ts
@@ -37,6 +37,9 @@ function jsonResponse(body: unknown, status = 200): Response {
 	return new Response(JSON.stringify(body), {
 		status,
 		statusText: status === 200 ? "OK" : "Error",
+		headers: {
+			"Content-Type": "application/json",
+		},
 	});
 }
 
@@ -48,31 +51,115 @@ function getFetchUrl(input: Parameters<typeof fetch>[0]): string {
 }
 
 describe("fetchWeatherData", () => {
-	it("throws a recoverable error when Open-Meteo returns no usable UV forecast", async () => {
-		globalThis.fetch = async () =>
-			jsonResponse(createForecastResponse([null, null, null]));
+	it("falls back to Google weather when Open-Meteo returns no usable UV forecast", async () => {
+		globalThis.fetch = async (input) => {
+			if (getFetchUrl(input).includes("/api/google-weather")) {
+				return jsonResponse({
+					current: {
+						dt: 1779810300,
+						temp: 76,
+						uvi: 3,
+						weather: [
+							{
+								id: 800,
+								main: "Sunny",
+								description: "Sunny",
+								icon: "",
+							},
+						],
+					},
+					hourly: [
+						{
+							dt: 1779810300,
+							temp: 76,
+							uvi: 3,
+							weather: [
+								{
+									id: 800,
+									main: "Sunny",
+									description: "Sunny",
+									icon: "",
+								},
+							],
+						},
+					],
+					elevation: 160,
+					sunrise: "2026-05-26T11:31:00.000Z",
+					sunset: "2026-05-27T01:24:00.000Z",
+					nextSunrise: "2026-05-27T11:31:00.000Z",
+					timezone: "America/Chicago",
+				});
+			}
+
+			return jsonResponse(createForecastResponse([null, null, null]));
+		};
+
+		const weather = await fetchWeatherData({
+			latitude: 30.2672,
+			longitude: -97.7431,
+		});
+
+		expect(weather.current.uvi).toBe(3);
+		expect(weather.timezone).toBe("America/Chicago");
+	});
+
+	it("throws a recoverable error when Open-Meteo and Google weather are unavailable", async () => {
+		globalThis.fetch = async (input) => {
+			if (getFetchUrl(input).includes("/api/google-weather")) {
+				return jsonResponse({ error: "Google weather unavailable" }, 502);
+			}
+
+			return jsonResponse(createForecastResponse([null, null, null]));
+		};
 
 		await expect(
 			fetchWeatherData({ latitude: 30.2672, longitude: -97.7431 }),
-		).rejects.toThrow("UV forecast is currently unavailable");
+		).rejects.toThrow("Weather providers unavailable");
+	});
+
+	it("throws a recoverable error when the Google fallback returns non-JSON", async () => {
+		globalThis.fetch = async (input) => {
+			if (getFetchUrl(input).includes("/api/google-weather")) {
+				return new Response("<html>not json</html>", {
+					status: 200,
+					headers: { "Content-Type": "text/html" },
+				});
+			}
+
+			return jsonResponse(createForecastResponse([null, null, null]));
+		};
+
+		await expect(
+			fetchWeatherData({ latitude: 30.2672, longitude: -97.7431 }),
+		).rejects.toThrow("Google weather fallback did not return JSON");
 	});
 
 	it("throws a recoverable error when Open-Meteo returns a partial UV forecast", async () => {
-		globalThis.fetch = async () =>
-			jsonResponse(createForecastResponse([0.8, 4.5, null], 0.8));
+		globalThis.fetch = async (input) => {
+			if (getFetchUrl(input).includes("/api/google-weather")) {
+				return jsonResponse({ error: "Google weather unavailable" }, 502);
+			}
+
+			return jsonResponse(createForecastResponse([0.8, 4.5, null], 0.8));
+		};
 
 		await expect(
 			fetchWeatherData({ latitude: 30.2672, longitude: -97.7431 }),
-		).rejects.toThrow("UV forecast is currently unavailable");
+		).rejects.toThrow("Weather providers unavailable");
 	});
 
 	it("throws a recoverable error when hourly UV values are unavailable", async () => {
-		globalThis.fetch = async () =>
-			jsonResponse(createForecastResponse([null, null, null], 0.8));
+		globalThis.fetch = async (input) => {
+			if (getFetchUrl(input).includes("/api/google-weather")) {
+				return jsonResponse({ error: "Google weather unavailable" }, 502);
+			}
+
+			return jsonResponse(createForecastResponse([null, null, null], 0.8));
+		};
 
 		await expect(
 			fetchWeatherData({ latitude: 30.2672, longitude: -97.7431 }),
-		).rejects.toThrow("UV forecast is currently unavailable");
+		).rejects.toThrow("Weather providers unavailable");
 	});
 
 	it("returns weather when Open-Meteo returns a complete UV forecast", async () => {

--- a/src/services/weather.ts
+++ b/src/services/weather.ts
@@ -71,6 +71,29 @@ function getHourlyUvIndex(hourly: OpenMeteoResponse["hourly"]): number[] {
 export async function fetchWeatherData(
 	position: Position,
 ): Promise<WeatherData> {
+	try {
+		return await fetchOpenMeteoWeatherData(position);
+	} catch (openMeteoError) {
+		console.warn(
+			"Open-Meteo weather failed, trying Google fallback:",
+			openMeteoError,
+		);
+
+		try {
+			return await fetchGoogleWeatherFallback(position);
+		} catch (googleError) {
+			throw new Error(
+				`Weather providers unavailable. Open-Meteo: ${getErrorMessage(
+					openMeteoError,
+				)} Google: ${getErrorMessage(googleError)}`,
+			);
+		}
+	}
+}
+
+export async function fetchOpenMeteoWeatherData(
+	position: Position,
+): Promise<WeatherData> {
 	const lat = position.latitude.toFixed(4);
 	const lon = position.longitude.toFixed(4);
 
@@ -174,4 +197,51 @@ export async function fetchWeatherData(
 		).toISOString(),
 		timezone: locationTimezone,
 	};
+}
+
+async function fetchGoogleWeatherFallback(
+	position: Position,
+): Promise<WeatherData> {
+	const params = new URLSearchParams({
+		latitude: position.latitude.toString(),
+		longitude: position.longitude.toString(),
+	});
+	const response = await fetch(`/api/google-weather?${params.toString()}`, {
+		headers: {
+			Accept: "application/json",
+		},
+	});
+
+	if (!response.ok) {
+		const message = await readErrorMessage(response);
+		throw new Error(
+			message || `Google weather fallback error: ${response.status}`,
+		);
+	}
+
+	const contentType = response.headers.get("content-type");
+	if (!contentType?.includes("application/json")) {
+		throw new Error("Google weather fallback did not return JSON");
+	}
+
+	return response.json();
+}
+
+async function readErrorMessage(
+	response: Response,
+): Promise<string | undefined> {
+	const contentType = response.headers.get("content-type");
+
+	if (contentType?.includes("application/json")) {
+		const body = (await response.json().catch(() => undefined)) as
+			| { error?: string }
+			| undefined;
+		return body?.error;
+	}
+
+	return response.text().catch(() => undefined);
+}
+
+function getErrorMessage(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
 }

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -2,7 +2,7 @@
 	"compilerOptions": {
 		"tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
 		"target": "ES2023",
-		"lib": ["ES2023"],
+		"lib": ["ES2023", "DOM"],
 		"module": "ESNext",
 		"skipLibCheck": true,
 
@@ -21,5 +21,6 @@
 		"noFallthroughCasesInSwitch": true,
 		"noUncheckedSideEffectImports": true
 	},
-	"include": ["vite.config.ts"]
+	"include": ["vite.config.ts", "api/**/*.ts"],
+	"exclude": ["api/**/*.test.ts"]
 }


### PR DESCRIPTION
## Summary
- keep Open-Meteo as the primary weather provider, but fall back to a server-side Google weather function when Open-Meteo fails or returns unusable UV data
- add /api/google-weather, backed by GOOGLE_MAPS_API_KEY, using Google hourly weather for temp/UV/conditions and Google daily weather for sunrise/sunset
- pull Google Elevation when available, but keep it non-fatal because elevation is display-only in the current app
- add regression coverage for the fallback path and Google response normalization

## Validation
- /Users/jon/.bun/bin/bun --bun run check
- /Users/jon/.bun/bin/bun --bun test
- /Users/jon/.bun/bin/bun --bun run build

## Notes
- PR #42 was already merged, so this is a follow-up PR on top of current master rather than another update to #42.