### PR TITLE
[codex] Add sunburn counter

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,27 @@ bun run build
 npm run build
 ```
 
+### Counter API
+
+The footer counter uses a Vercel Function at `/api/sunburn-counter` backed by
+Redis. For production, configure:
+
+```bash
+REDIS_URL=redis://default:<password>@<railway-proxy-host>:<port>
+COUNTER_HASH_SECRET=<long-random-string>
+```
+
+Optional:
+
+```bash
+COUNTER_ALLOWED_ORIGINS=https://sunburntimer.com,https://www.sunburntimer.com
+VITE_COUNTER_API_BASE_URL=https://sunburntimer.com
+```
+
+Run with `vercel dev` when you want the local Vercel Function available during
+frontend development. Plain `bun dev` runs only the Vite app, so the counter
+stays hidden unless `VITE_COUNTER_API_BASE_URL` points at an API backend.
+
 ## Usage
 
 1. **Select Your Skin Type**: Choose from the Fitzpatrick scale (I-VI) based on your skin's reaction to sun exposure
@@ -140,7 +161,8 @@ src/
 ## Security & Privacy
 
 - No API keys required - uses free public APIs
-- No personal data is stored on servers
+- The counter stores only an aggregate total plus temporary 24-hour dedupe keys
+  derived from a one-way HMAC of request metadata
 - User preferences saved locally with Zustand persist
 - HTTPS enforced for all API calls
 

--- a/README.md
+++ b/README.md
@@ -78,12 +78,12 @@ Redis. For production, configure:
 ```bash
 REDIS_URL=redis://default:<password>@<railway-proxy-host>:<port>
 COUNTER_HASH_SECRET=<long-random-string>
+COUNTER_ALLOWED_ORIGINS=https://sunburntimer.com,https://www.sunburntimer.com
 ```
 
 Optional:
 
 ```bash
-COUNTER_ALLOWED_ORIGINS=https://sunburntimer.com,https://www.sunburntimer.com
 VITE_COUNTER_API_BASE_URL=https://sunburntimer.com
 ```
 

--- a/api/sunburn-counter.ts
+++ b/api/sunburn-counter.ts
@@ -55,25 +55,7 @@ function isAllowedOrigin(request: VercelRequest) {
 		.map((allowedOrigin) => allowedOrigin.trim())
 		.filter(Boolean);
 
-	if (allowedOrigins?.includes(origin)) {
-		return true;
-	}
-
-	try {
-		const originHost = new URL(origin).host;
-		const hostCandidates = [
-			getHeader(request, "x-forwarded-host"),
-			getHeader(request, "host"),
-		].filter(Boolean);
-
-		return hostCandidates.some((host) => {
-			const normalizedOriginHost = originHost.replace(/^www\./, "");
-			const normalizedHost = host?.replace(/^www\./, "");
-			return originHost === host || normalizedOriginHost === normalizedHost;
-		});
-	} catch {
-		return false;
-	}
+	return allowedOrigins?.includes(origin) ?? false;
 }
 
 function getAllowedOrigin(request: VercelRequest) {

--- a/api/sunburn-counter.ts
+++ b/api/sunburn-counter.ts
@@ -76,6 +76,11 @@ function isAllowedOrigin(request: VercelRequest) {
 	}
 }
 
+function getAllowedOrigin(request: VercelRequest) {
+	const origin = getHeader(request, "origin");
+	return origin && isAllowedOrigin(request) ? origin : undefined;
+}
+
 function getVisitorHash(request: VercelRequest) {
 	const forwardedFor = getHeader(request, "x-forwarded-for");
 	const ipAddress =
@@ -96,12 +101,21 @@ function getVisitorHash(request: VercelRequest) {
 }
 
 function sendCounter(
+	request: VercelRequest,
 	response: VercelResponse,
 	count: number,
 	cacheControl: string,
 ) {
+	const allowedOrigin = getAllowedOrigin(request);
+
 	response.setHeader("Cache-Control", cacheControl);
-	response.json({ sunburnsAvoided: count });
+	response.setHeader("Vary", "Origin");
+
+	if (allowedOrigin) {
+		response.setHeader("Access-Control-Allow-Origin", allowedOrigin);
+	}
+
+	response.json({ sunburnsAvoided: Number.isFinite(count) ? count : 0 });
 }
 
 export default async function handler(
@@ -124,12 +138,19 @@ export default async function handler(
 
 		if (request.method === "GET") {
 			const count = Number((await redis.get(COUNTER_KEY)) ?? 0);
-			sendCounter(response, count, "s-maxage=300, stale-while-revalidate=3600");
+			sendCounter(
+				request,
+				response,
+				count,
+				"s-maxage=300, stale-while-revalidate=3600",
+			);
 			return;
 		}
 
 		const visitorHash = getVisitorHash(request);
 		const dedupeKey = `${COUNTER_KEY}:dedupe:${visitorHash}`;
+		// If INCR fails after this succeeds, this visitor may be undercounted until
+		// the dedupe key expires. That is acceptable for a vanity counter.
 		const wasRecorded = await redis.set(dedupeKey, "1", {
 			EX: DEDUPE_TTL_SECONDS,
 			NX: true,
@@ -139,7 +160,7 @@ export default async function handler(
 				? await redis.incr(COUNTER_KEY)
 				: Number((await redis.get(COUNTER_KEY)) ?? 0);
 
-		sendCounter(response, count, "no-store");
+		sendCounter(request, response, count, "no-store");
 	} catch (error) {
 		console.error(error);
 		response.status(500).json({ error: "Counter unavailable" });

--- a/api/sunburn-counter.ts
+++ b/api/sunburn-counter.ts
@@ -1,0 +1,147 @@
+import { createHmac } from "node:crypto";
+import { createClient } from "redis";
+
+type VercelRequest = {
+	headers: Record<string, string | string[] | undefined>;
+	method?: string;
+};
+
+type VercelResponse = {
+	json: (body: unknown) => void;
+	setHeader: (name: string, value: string) => void;
+	status: (statusCode: number) => VercelResponse;
+};
+
+const COUNTER_KEY = "sunburns_avoided";
+const DEDUPE_TTL_SECONDS = 60 * 60 * 24;
+
+let redisClient: ReturnType<typeof createClient> | undefined;
+
+function getHeader(request: VercelRequest, name: string) {
+	const value = request.headers[name] ?? request.headers[name.toLowerCase()];
+	return Array.isArray(value) ? value[0] : value;
+}
+
+async function getRedisClient() {
+	if (!process.env.REDIS_URL) {
+		throw new Error("REDIS_URL is not configured");
+	}
+
+	if (!redisClient) {
+		redisClient = createClient({
+			url: process.env.REDIS_URL,
+		});
+
+		redisClient.on("error", (error) => {
+			console.error("Redis error", error);
+		});
+	}
+
+	if (!redisClient.isOpen) {
+		await redisClient.connect();
+	}
+
+	return redisClient;
+}
+
+function isAllowedOrigin(request: VercelRequest) {
+	const origin = getHeader(request, "origin");
+
+	if (!origin) {
+		return false;
+	}
+
+	const allowedOrigins = process.env.COUNTER_ALLOWED_ORIGINS?.split(",")
+		.map((allowedOrigin) => allowedOrigin.trim())
+		.filter(Boolean);
+
+	if (allowedOrigins?.includes(origin)) {
+		return true;
+	}
+
+	try {
+		const originHost = new URL(origin).host;
+		const hostCandidates = [
+			getHeader(request, "x-forwarded-host"),
+			getHeader(request, "host"),
+		].filter(Boolean);
+
+		return hostCandidates.some((host) => {
+			const normalizedOriginHost = originHost.replace(/^www\./, "");
+			const normalizedHost = host?.replace(/^www\./, "");
+			return originHost === host || normalizedOriginHost === normalizedHost;
+		});
+	} catch {
+		return false;
+	}
+}
+
+function getVisitorHash(request: VercelRequest) {
+	const forwardedFor = getHeader(request, "x-forwarded-for");
+	const ipAddress =
+		forwardedFor?.split(",")[0]?.trim() ??
+		getHeader(request, "x-real-ip") ??
+		"unknown";
+	const userAgent = getHeader(request, "user-agent") ?? "unknown";
+	const language = getHeader(request, "accept-language") ?? "unknown";
+	const secret = process.env.COUNTER_HASH_SECRET;
+
+	if (!secret) {
+		throw new Error("COUNTER_HASH_SECRET is not configured");
+	}
+
+	return createHmac("sha256", secret)
+		.update(`${ipAddress}|${userAgent}|${language}`)
+		.digest("hex");
+}
+
+function sendCounter(
+	response: VercelResponse,
+	count: number,
+	cacheControl: string,
+) {
+	response.setHeader("Cache-Control", cacheControl);
+	response.json({ sunburnsAvoided: count });
+}
+
+export default async function handler(
+	request: VercelRequest,
+	response: VercelResponse,
+) {
+	if (request.method !== "GET" && request.method !== "POST") {
+		response.setHeader("Allow", "GET, POST");
+		response.status(405).json({ error: "Method not allowed" });
+		return;
+	}
+
+	if (request.method === "POST" && !isAllowedOrigin(request)) {
+		response.status(403).json({ error: "Forbidden" });
+		return;
+	}
+
+	try {
+		const redis = await getRedisClient();
+
+		if (request.method === "GET") {
+			const count = Number((await redis.get(COUNTER_KEY)) ?? 0);
+			sendCounter(response, count, "s-maxage=300, stale-while-revalidate=3600");
+			return;
+		}
+
+		const visitorHash = getVisitorHash(request);
+		const dedupeKey = `${COUNTER_KEY}:dedupe:${visitorHash}`;
+		const wasRecorded = await redis.set(dedupeKey, "1", {
+			EX: DEDUPE_TTL_SECONDS,
+			NX: true,
+		});
+		const count =
+			wasRecorded === "OK"
+				? await redis.incr(COUNTER_KEY)
+				: Number((await redis.get(COUNTER_KEY)) ?? 0);
+
+		sendCounter(response, count, "no-store");
+	} catch (error) {
+		console.error(error);
+		response.status(500).json({ error: "Counter unavailable" });
+	}
+}

--- a/bun.lock
+++ b/bun.lock
@@ -27,6 +27,7 @@
         "react": "^19.1.0",
         "react-chartjs-2": "^5.3.0",
         "react-dom": "^19.1.0",
+        "redis": "^6.0.0",
         "tailwind-merge": "^3.3.1",
         "tailwindcss": "^4.1.11",
         "zustand": "^5.0.6",
@@ -279,6 +280,16 @@
 
     "@radix-ui/rect": ["@radix-ui/rect@1.1.1", "", {}, "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw=="],
 
+    "@redis/bloom": ["@redis/bloom@6.0.0", "", { "peerDependencies": { "@redis/client": "^6.0.0" } }, "sha512-P0n5NkV9IIdT6nYXOfMHG83sho8pE7Nay7yw27wOGVLv4DthgvzebpGz6m7VuMTizeJmw3LPw2Xek5wFUhGpVw=="],
+
+    "@redis/client": ["@redis/client@6.0.0", "", { "dependencies": { "cluster-key-slot": "1.1.2" }, "peerDependencies": { "@node-rs/xxhash": "^1.1.0", "@opentelemetry/api": ">=1 <2" }, "optionalPeers": ["@node-rs/xxhash", "@opentelemetry/api"] }, "sha512-NS4iIT25r24sAjNQ2nSRdCW5jPJoV0rxkBee27oTeR+RXaOu89cjIsrww5rPBaYVGVdL1QCx9uz9141gZiSKdQ=="],
+
+    "@redis/json": ["@redis/json@6.0.0", "", { "peerDependencies": { "@redis/client": "^6.0.0" } }, "sha512-F+eqFfgPcy57Zs1KW7UtLnBtRk6lxAUIoe7dyZerpm6e+ssYXG/dWJrbrHFYs0b7tt6QBtYpVuukBuM9XqhUAg=="],
+
+    "@redis/search": ["@redis/search@6.0.0", "", { "peerDependencies": { "@redis/client": "^6.0.0" } }, "sha512-VHuCJ2W0YWFixGZh/l//8JiyOsD4gN+NhjdRAGIoUe0UQ4mtq1NyY2ZJ973XT+vYhaU21XdK8r8oNrd5n7wbzQ=="],
+
+    "@redis/time-series": ["@redis/time-series@6.0.0", "", { "peerDependencies": { "@redis/client": "^6.0.0" } }, "sha512-QWhkYsg+3lhBrBf+cbzybtV8LQcSrk7iXIgTaGU+pHNFTkql7TpVRE24ROS6M2ybVIV6O/zxTqfxgxxYiqyw0Q=="],
+
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-beta.19", "", {}, "sha512-3FL3mnMbPu0muGOCaKAhhFEYmqv9eTfPSJRJmANrCwtgK8VuxpsZDGK+m0LYAGoyO8+0j5uRe4PeyPDK1yA/hA=="],
 
     "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.44.1", "", { "os": "android", "cpu": "arm" }, "sha512-JAcBr1+fgqx20m7Fwe1DxPUl/hPkee6jA6Pl7n1v2EFiktAHenTaXl5aIFjUIEsfn9w3HE4gK1lEgNGMzBDs1w=="],
@@ -436,6 +447,8 @@
     "class-variance-authority": ["class-variance-authority@0.7.1", "", { "dependencies": { "clsx": "^2.1.1" } }, "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg=="],
 
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
+
+    "cluster-key-slot": ["cluster-key-slot@1.1.2", "", {}, "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA=="],
 
     "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 
@@ -652,6 +665,8 @@
     "react-remove-scroll-bar": ["react-remove-scroll-bar@2.3.8", "", { "dependencies": { "react-style-singleton": "^2.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react"] }, "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q=="],
 
     "react-style-singleton": ["react-style-singleton@2.2.3", "", { "dependencies": { "get-nonce": "^1.0.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ=="],
+
+    "redis": ["redis@6.0.0", "", { "dependencies": { "@redis/bloom": "6.0.0", "@redis/client": "6.0.0", "@redis/json": "6.0.0", "@redis/search": "6.0.0", "@redis/time-series": "6.0.0" } }, "sha512-n9Thfc39OXleEoPT2k5gwKsqY+HfCww3YS71ofcr9KKbkn89bpjU9dToIlD+JRdM3/GYQkwMtVgTxLyed+LptQ=="],
 
     "resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
 

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
 		"react": "^19.1.0",
 		"react-chartjs-2": "^5.3.0",
 		"react-dom": "^19.1.0",
+		"redis": "^6.0.0",
 		"tailwind-merge": "^3.3.1",
 		"tailwindcss": "^4.1.11",
 		"zustand": "^5.0.6"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -36,6 +36,7 @@ import { SunTimer } from "./components/SunTimer";
 import { RelativeTime } from "./components/RelativeTime";
 import { MathExplanation } from "./components/MathExplanation";
 import { SunPositionCard } from "./components/SunPositionCard";
+import { SunburnCounter } from "./components/SunburnCounter";
 
 function App() {
 	const {
@@ -332,7 +333,7 @@ function App() {
 
 				{/* Footer */}
 				<footer className="mt-16 pt-8 border-t border-stone-200">
-					<div className="flex flex-col sm:flex-row items-center justify-between gap-4 text-sm text-slate-600">
+					<div className="flex flex-col sm:flex-row items-center justify-between gap-5 text-sm text-slate-600">
 						<div className="flex items-center gap-4">
 							<span>Made by</span>
 							<a
@@ -344,6 +345,7 @@ function App() {
 								Jon Callahan
 							</a>
 						</div>
+						<SunburnCounter shouldRecord={!!calculation} />
 						<div className="flex items-center gap-4">
 							<a
 								href="https://github.com/jondcallahan/sunburntimer"

--- a/src/components/SunburnCounter.tsx
+++ b/src/components/SunburnCounter.tsx
@@ -73,6 +73,11 @@ export function SunburnCounter({ shouldRecord }: SunburnCounterProps) {
 
 		recordSunburnAvoided()
 			.then((nextCount) => {
+				if (nextCount === null) {
+					hasRecordedCounterThisSession = false;
+					return;
+				}
+
 				if (!ignore) {
 					setCount((currentCount) => getNewestCount(currentCount, nextCount));
 				}

--- a/src/components/SunburnCounter.tsx
+++ b/src/components/SunburnCounter.tsx
@@ -8,6 +8,8 @@ type SunburnCounterProps = {
 	shouldRecord: boolean;
 };
 
+let hasRecordedCounterThisSession = false;
+
 function getCounterDigits(count: number) {
 	return Math.max(0, Math.floor(count)).toLocaleString("en-US", {
 		useGrouping: true,
@@ -62,11 +64,12 @@ export function SunburnCounter({ shouldRecord }: SunburnCounterProps) {
 	}, []);
 
 	useEffect(() => {
-		if (!shouldRecord) {
+		if (!shouldRecord || hasRecordedCounterThisSession) {
 			return;
 		}
 
 		let ignore = false;
+		hasRecordedCounterThisSession = true;
 
 		recordSunburnAvoided()
 			.then((nextCount) => {
@@ -74,7 +77,9 @@ export function SunburnCounter({ shouldRecord }: SunburnCounterProps) {
 					setCount((currentCount) => getNewestCount(currentCount, nextCount));
 				}
 			})
-			.catch(() => undefined);
+			.catch(() => {
+				hasRecordedCounterThisSession = false;
+			});
 
 		return () => {
 			ignore = true;

--- a/src/components/SunburnCounter.tsx
+++ b/src/components/SunburnCounter.tsx
@@ -1,0 +1,107 @@
+import { useEffect, useState } from "react";
+import {
+	fetchSunburnCounter,
+	recordSunburnAvoided,
+} from "@/services/sunburn-counter";
+
+type SunburnCounterProps = {
+	shouldRecord: boolean;
+};
+
+function getCounterDigits(count: number) {
+	return Math.max(0, Math.floor(count)).toLocaleString("en-US", {
+		useGrouping: true,
+	});
+}
+
+function getCounterDigitItems(count: number) {
+	const seenDigits = new Map<string, number>();
+
+	return getCounterDigits(count)
+		.split("")
+		.map((digit) => {
+			const seenCount = seenDigits.get(digit) ?? 0;
+			seenDigits.set(digit, seenCount + 1);
+
+			return {
+				digit,
+				key: `${digit}-${seenCount}`,
+			};
+		});
+}
+
+function getNewestCount(currentCount: number | null, nextCount: number | null) {
+	if (nextCount === null) {
+		return currentCount;
+	}
+
+	return currentCount === null ? nextCount : Math.max(currentCount, nextCount);
+}
+
+export function SunburnCounter({ shouldRecord }: SunburnCounterProps) {
+	const [count, setCount] = useState<number | null>(null);
+
+	useEffect(() => {
+		let ignore = false;
+
+		fetchSunburnCounter()
+			.then((nextCount) => {
+				if (!ignore) {
+					setCount((currentCount) => getNewestCount(currentCount, nextCount));
+				}
+			})
+			.catch(() => {
+				if (!ignore) {
+					setCount(null);
+				}
+			});
+
+		return () => {
+			ignore = true;
+		};
+	}, []);
+
+	useEffect(() => {
+		if (!shouldRecord) {
+			return;
+		}
+
+		let ignore = false;
+
+		recordSunburnAvoided()
+			.then((nextCount) => {
+				if (!ignore) {
+					setCount((currentCount) => getNewestCount(currentCount, nextCount));
+				}
+			})
+			.catch(() => undefined);
+
+		return () => {
+			ignore = true;
+		};
+	}, [shouldRecord]);
+
+	if (count === null) {
+		return null;
+	}
+
+	const digits = getCounterDigitItems(count);
+
+	return (
+		<div className="sunburn-counter">
+			<span className="sr-only">{count} sunburns avoided</span>
+			<div className="sunburn-counter__display" aria-hidden="true">
+				{digits.map(({ digit, key }) => (
+					<span
+						className="sunburn-counter__digit"
+						key={key}
+						data-comma={digit === "," ? "true" : undefined}
+					>
+						{digit}
+					</span>
+				))}
+			</div>
+			<span className="sunburn-counter__label">sunburns avoided</span>
+		</div>
+	);
+}

--- a/src/index.css
+++ b/src/index.css
@@ -155,3 +155,43 @@
 .sun-pulse {
 	animation: sun-pulse 2s ease-in-out infinite;
 }
+
+.sunburn-counter {
+	@apply flex items-center gap-2 rounded-md border border-stone-200/90 bg-white/70 px-3 py-2 text-slate-600 shadow-sm;
+	box-shadow:
+		inset 0 1px 0 rgb(255 255 255 / 0.8),
+		0 10px 24px rgb(120 53 15 / 0.08);
+}
+
+.sunburn-counter__display {
+	@apply flex items-center gap-0.5 rounded-sm border border-slate-900/80 bg-slate-950 px-1.5 py-1;
+	box-shadow:
+		inset 0 1px 2px rgb(255 255 255 / 0.18),
+		inset 0 -8px 16px rgb(0 0 0 / 0.28);
+}
+
+.sunburn-counter__digit {
+	@apply inline-flex h-6 min-w-4 items-center justify-center rounded-[3px] border border-slate-700 bg-slate-900 px-1 text-sm font-bold leading-none text-amber-200;
+	font-family:
+		"SFMono-Regular", "Consolas", "Liberation Mono", ui-monospace, monospace;
+	font-variant-numeric: tabular-nums;
+	text-shadow: 0 0 8px rgb(252 211 77 / 0.42);
+	box-shadow:
+		inset 0 1px 0 rgb(255 255 255 / 0.1),
+		inset 0 -1px 0 rgb(0 0 0 / 0.8);
+}
+
+.sunburn-counter__digit[data-comma="true"] {
+	@apply min-w-2 border-transparent bg-transparent px-0 text-amber-300;
+	box-shadow: none;
+}
+
+.sunburn-counter__label {
+	@apply text-xs font-medium uppercase tracking-[0.08em] text-slate-500;
+}
+
+@media (max-width: 640px) {
+	.sunburn-counter {
+		@apply order-first;
+	}
+}

--- a/src/services/sunburn-counter.test.ts
+++ b/src/services/sunburn-counter.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { fetchSunburnCounter, recordSunburnAvoided } from "./sunburn-counter";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+	globalThis.fetch = originalFetch;
+});
+
+function jsonResponse(body: unknown, status = 200): Response {
+	return new Response(JSON.stringify(body), {
+		status,
+		statusText: status === 200 ? "OK" : "Error",
+	});
+}
+
+describe("sunburn counter service", () => {
+	it("fetches a counter from the sunburnsAvoided field", async () => {
+		globalThis.fetch = async () => jsonResponse({ sunburnsAvoided: 12847 });
+
+		await expect(fetchSunburnCounter()).resolves.toBe(12847);
+	});
+
+	it("accepts the legacy count field", async () => {
+		globalThis.fetch = async () => jsonResponse({ count: 42 });
+
+		await expect(fetchSunburnCounter()).resolves.toBe(42);
+	});
+
+	it("returns null for non-200 responses", async () => {
+		globalThis.fetch = async () => jsonResponse({ error: "Nope" }, 500);
+
+		await expect(fetchSunburnCounter()).resolves.toBeNull();
+	});
+
+	it("returns null for malformed counter responses", async () => {
+		globalThis.fetch = async () => jsonResponse({ sunburnsAvoided: "NaN" });
+
+		await expect(fetchSunburnCounter()).resolves.toBeNull();
+	});
+
+	it("posts the counter record request with keepalive", async () => {
+		let method = "";
+		let keepalive = false;
+
+		globalThis.fetch = async (_input, init) => {
+			method = init?.method ?? "";
+			keepalive = init?.keepalive ?? false;
+			return jsonResponse({ sunburnsAvoided: 12848 });
+		};
+
+		await expect(recordSunburnAvoided()).resolves.toBe(12848);
+		expect(method).toBe("POST");
+		expect(keepalive).toBe(true);
+	});
+});

--- a/src/services/sunburn-counter.test.ts
+++ b/src/services/sunburn-counter.test.ts
@@ -21,12 +21,6 @@ describe("sunburn counter service", () => {
 		await expect(fetchSunburnCounter()).resolves.toBe(12847);
 	});
 
-	it("accepts the legacy count field", async () => {
-		globalThis.fetch = async () => jsonResponse({ count: 42 });
-
-		await expect(fetchSunburnCounter()).resolves.toBe(42);
-	});
-
 	it("returns null for non-200 responses", async () => {
 		globalThis.fetch = async () => jsonResponse({ error: "Nope" }, 500);
 

--- a/src/services/sunburn-counter.ts
+++ b/src/services/sunburn-counter.ts
@@ -5,7 +5,6 @@ const COUNTER_ENDPOINT = `${COUNTER_API_BASE_URL}/api/sunburn-counter`;
 
 type CounterStatsResponse = {
 	sunburnsAvoided?: number;
-	count?: number;
 };
 
 export async function fetchSunburnCounter(): Promise<number | null> {
@@ -20,7 +19,7 @@ export async function fetchSunburnCounter(): Promise<number | null> {
 	}
 
 	const stats = (await response.json()) as CounterStatsResponse;
-	const count = stats.sunburnsAvoided ?? stats.count;
+	const count = stats.sunburnsAvoided;
 
 	return typeof count === "number" && Number.isFinite(count) ? count : null;
 }
@@ -39,7 +38,7 @@ export async function recordSunburnAvoided(): Promise<number | null> {
 	}
 
 	const stats = (await response.json()) as CounterStatsResponse;
-	const count = stats.sunburnsAvoided ?? stats.count;
+	const count = stats.sunburnsAvoided;
 
 	return typeof count === "number" && Number.isFinite(count) ? count : null;
 }

--- a/src/services/sunburn-counter.ts
+++ b/src/services/sunburn-counter.ts
@@ -1,0 +1,45 @@
+const COUNTER_API_BASE_URL =
+	import.meta.env.VITE_COUNTER_API_BASE_URL?.replace(/\/$/, "") ?? "";
+
+const COUNTER_ENDPOINT = `${COUNTER_API_BASE_URL}/api/sunburn-counter`;
+
+type CounterStatsResponse = {
+	sunburnsAvoided?: number;
+	count?: number;
+};
+
+export async function fetchSunburnCounter(): Promise<number | null> {
+	const response = await fetch(COUNTER_ENDPOINT, {
+		headers: {
+			Accept: "application/json",
+		},
+	});
+
+	if (!response.ok) {
+		return null;
+	}
+
+	const stats = (await response.json()) as CounterStatsResponse;
+	const count = stats.sunburnsAvoided ?? stats.count;
+
+	return typeof count === "number" && Number.isFinite(count) ? count : null;
+}
+
+export async function recordSunburnAvoided(): Promise<number | null> {
+	const response = await fetch(COUNTER_ENDPOINT, {
+		headers: {
+			Accept: "application/json",
+		},
+		keepalive: true,
+		method: "POST",
+	});
+
+	if (!response.ok) {
+		return null;
+	}
+
+	const stats = (await response.json()) as CounterStatsResponse;
+	const count = stats.sunburnsAvoided ?? stats.count;
+
+	return typeof count === "number" && Number.isFinite(count) ? count : null;
+}

--- a/tsconfig.api.json
+++ b/tsconfig.api.json
@@ -1,0 +1,27 @@
+{
+	"compilerOptions": {
+		"tsBuildInfoFile": "./node_modules/.tmp/tsconfig.api.tsbuildinfo",
+		"target": "ES2023",
+		"lib": ["ES2023"],
+		"module": "ESNext",
+		"skipLibCheck": true,
+
+		/* Bundler mode */
+		"moduleResolution": "bundler",
+		"allowImportingTsExtensions": true,
+		"verbatimModuleSyntax": true,
+		"moduleDetection": "force",
+		"noEmit": true,
+
+		/* Linting */
+		"strict": true,
+		"noUnusedLocals": true,
+		"noUnusedParameters": true,
+		"erasableSyntaxOnly": true,
+		"noFallthroughCasesInSwitch": true,
+		"noUncheckedSideEffectImports": true,
+
+		"types": ["node"]
+	},
+	"include": ["api/**/*.ts"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,8 @@
 	"files": [],
 	"references": [
 		{ "path": "./tsconfig.app.json" },
-		{ "path": "./tsconfig.node.json" }
+		{ "path": "./tsconfig.node.json" },
+		{ "path": "./tsconfig.api.json" }
 	],
 	"compilerOptions": {
 		"baseUrl": ".",


### PR DESCRIPTION
## Summary
- add a Redis-backed Vercel Function for `/api/sunburn-counter`
- add a retro-styled footer counter that records once a calculation is available
- document the required Vercel environment variables and privacy behavior
- include API TypeScript coverage in the root build

## Validation
- `bun run check`
- `bun run build`

## Notes
- Production needs `REDIS_URL`, `COUNTER_HASH_SECRET`, and the configured `COUNTER_ALLOWED_ORIGINS` values in Vercel.
- The existing Vite large chunk warning is still present and unrelated to this change.