### PR TITLE
Scale environmental UV factors in the dose integral

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -80,7 +80,9 @@ function App() {
 			sweatLevel: sweatLevel ?? DEFAULT_SWEAT_LEVEL,
 		};
 
-		const result = findOptimalTimeSlicing(input);
+		const result = findOptimalTimeSlicing(input, {
+			includeEnvironmentalScenarios: true,
+		});
 		setCalculation(result);
 	}, [
 		isReadyToCalculate,

--- a/src/calculations.test.ts
+++ b/src/calculations.test.ts
@@ -675,8 +675,7 @@ describe("Sunburn Calculation Algorithm", () => {
 		});
 
 		it("should re-integrate scenarios rather than scale final duration only", () => {
-			// Rising UV + SPF decay: dose-rate scaling is non-linear in clock time
-			// (higher dose can exhaust MED while SPF is still high → not simply base/factor)
+			// Variable UV + SPF decay: clock time is non-linear in the dose multiplier
 			const input = createTestScenario(
 				FitzpatrickType.II,
 				SPFLevel.SPF_15,
@@ -702,10 +701,8 @@ describe("Sunburn Calculation Algorithm", () => {
 			const integratedSnowMs = snowBurn.getTime() - input.currentTime.getTime();
 			const shadeMs = shadeBurn.getTime() - input.currentTime.getTime();
 
-			// Ordering from dose-rate scaling
 			expect(integratedSnowMs).toBeLessThan(baseMs);
 			expect(shadeMs).toBeGreaterThan(baseMs);
-			// Material difference from post-hoc time division (non-linear SPF/UV path)
 			expect(Math.abs(integratedSnowMs - naiveSnowMs)).toBeGreaterThan(60_000);
 		});
 

--- a/src/calculations.test.ts
+++ b/src/calculations.test.ts
@@ -1,7 +1,15 @@
 import { describe, it, expect } from "bun:test";
-import { findOptimalTimeSlicing } from "./calculations";
+import {
+	findOptimalTimeSlicing,
+	calculateEnvironmentalBurnTimes,
+} from "./calculations";
 import type { CalculationInput, WeatherData, CalculationResult } from "./types";
-import { FitzpatrickType, SPFLevel, SweatLevel } from "./types";
+import {
+	FitzpatrickType,
+	SPFLevel,
+	SweatLevel,
+	ENVIRONMENTAL_MULTIPLIERS,
+} from "./types";
 
 // Test helper functions
 function createMockWeatherData(
@@ -605,6 +613,115 @@ describe("Sunburn Calculation Algorithm", () => {
 			if (lowSweatTime !== Infinity && highSweatTime !== Infinity) {
 				expect(highSweatTime).toBeLessThanOrEqual(lowSweatTime);
 			}
+		});
+	});
+
+	describe("Environmental dose-rate scaling", () => {
+		const fixedTime = new Date("2025-06-21T12:00:00Z");
+
+		it("should burn faster when environmental factor increases dose rate", () => {
+			const base = createTestScenario(
+				FitzpatrickType.I,
+				SPFLevel.NONE,
+				SweatLevel.LOW,
+				Array(8).fill(8),
+				fixedTime,
+			);
+			const snow = { ...base, environmentalFactor: ENVIRONMENTAL_MULTIPLIERS.SNOW };
+			const shade = {
+				...base,
+				environmentalFactor: ENVIRONMENTAL_MULTIPLIERS.SHADE,
+			};
+
+			const baseResult = findOptimalTimeSlicing(base);
+			const snowResult = findOptimalTimeSlicing(snow);
+			const shadeResult = findOptimalTimeSlicing(shade);
+
+			const baseMin = getBurnTimeMinutes(baseResult, base);
+			const snowMin = getBurnTimeMinutes(snowResult, snow);
+			const shadeMin = getBurnTimeMinutes(shadeResult, shade);
+
+			expect(baseMin).not.toBe(Infinity);
+			expect(snowMin).toBeLessThan(baseMin);
+			expect(shadeMin).toBeGreaterThan(baseMin);
+		});
+
+		it("should approximate 1/factor under constant UV and constant SPF (no sweat decay)", () => {
+			// Constant conditions: burn time scales as 1 / environmentalFactor
+			const base = createTestScenario(
+				FitzpatrickType.I,
+				SPFLevel.NONE,
+				SweatLevel.LOW,
+				Array(10).fill(8),
+				fixedTime,
+			);
+			const sand = { ...base, environmentalFactor: ENVIRONMENTAL_MULTIPLIERS.SAND };
+
+			const baseMin = getBurnTimeMinutes(findOptimalTimeSlicing(base), base);
+			const sandMin = getBurnTimeMinutes(findOptimalTimeSlicing(sand), sand);
+
+			expect(baseMin).not.toBe(Infinity);
+			expect(sandMin).not.toBe(Infinity);
+
+			const expected = baseMin / ENVIRONMENTAL_MULTIPLIERS.SAND;
+			// Trapezoid / slice quantization: allow small absolute error
+			expect(Math.abs(sandMin - expected)).toBeLessThan(1.5);
+		});
+
+		it("should re-integrate scenarios rather than scale final duration only", () => {
+			// Rising UV + SPF decay: dose-rate scaling is non-linear in clock time
+			// (higher dose can exhaust MED while SPF is still high → not simply base/factor)
+			const input = createTestScenario(
+				FitzpatrickType.II,
+				SPFLevel.SPF_15,
+				SweatLevel.HIGH,
+				[3, 5, 8, 10, 11, 9, 6, 3],
+				fixedTime,
+			);
+
+			const withEnv = findOptimalTimeSlicing(input, {
+				includeEnvironmentalScenarios: true,
+			});
+			expect(withEnv.environmentalBurnTimes).toBeDefined();
+			expect(withEnv.burnTime).toBeDefined();
+			expect(withEnv.environmentalBurnTimes?.snow).toBeDefined();
+			expect(withEnv.environmentalBurnTimes?.shade).toBeDefined();
+
+			const baseMs =
+				withEnv.burnTime!.getTime() - input.currentTime.getTime();
+			const naiveSnowMs = baseMs / ENVIRONMENTAL_MULTIPLIERS.SNOW;
+			const integratedSnowMs =
+				withEnv.environmentalBurnTimes!.snow!.getTime() -
+				input.currentTime.getTime();
+			const shadeMs =
+				withEnv.environmentalBurnTimes!.shade!.getTime() -
+				input.currentTime.getTime();
+
+			// Ordering from dose-rate scaling
+			expect(integratedSnowMs).toBeLessThan(baseMs);
+			expect(shadeMs).toBeGreaterThan(baseMs);
+			// Material difference from post-hoc time division (non-linear SPF/UV path)
+			expect(Math.abs(integratedSnowMs - naiveSnowMs)).toBeGreaterThan(
+				60_000,
+			);
+		});
+
+		it("calculateEnvironmentalBurnTimes returns ordered risk snow < sand < shade", () => {
+			const input = createTestScenario(
+				FitzpatrickType.I,
+				SPFLevel.NONE,
+				SweatLevel.LOW,
+				Array(8).fill(7),
+				fixedTime,
+			);
+			const env = calculateEnvironmentalBurnTimes(input);
+			expect(env.snow).toBeDefined();
+			expect(env.sand).toBeDefined();
+			expect(env.shade).toBeDefined();
+
+			const t = (d?: Date) => d!.getTime();
+			expect(t(env.snow)).toBeLessThan(t(env.sand));
+			expect(t(env.sand)).toBeLessThan(t(env.shade));
 		});
 	});
 });

--- a/src/calculations.test.ts
+++ b/src/calculations.test.ts
@@ -627,7 +627,10 @@ describe("Sunburn Calculation Algorithm", () => {
 				Array(8).fill(8),
 				fixedTime,
 			);
-			const snow = { ...base, environmentalFactor: ENVIRONMENTAL_MULTIPLIERS.SNOW };
+			const snow = {
+				...base,
+				environmentalFactor: ENVIRONMENTAL_MULTIPLIERS.SNOW,
+			};
 			const shade = {
 				...base,
 				environmentalFactor: ENVIRONMENTAL_MULTIPLIERS.SHADE,
@@ -655,7 +658,10 @@ describe("Sunburn Calculation Algorithm", () => {
 				Array(10).fill(8),
 				fixedTime,
 			);
-			const sand = { ...base, environmentalFactor: ENVIRONMENTAL_MULTIPLIERS.SAND };
+			const sand = {
+				...base,
+				environmentalFactor: ENVIRONMENTAL_MULTIPLIERS.SAND,
+			};
 
 			const baseMin = getBurnTimeMinutes(findOptimalTimeSlicing(base), base);
 			const sandMin = getBurnTimeMinutes(findOptimalTimeSlicing(sand), sand);
@@ -682,28 +688,25 @@ describe("Sunburn Calculation Algorithm", () => {
 			const withEnv = findOptimalTimeSlicing(input, {
 				includeEnvironmentalScenarios: true,
 			});
-			expect(withEnv.environmentalBurnTimes).toBeDefined();
+			const snowBurn = withEnv.environmentalBurnTimes?.snow;
+			const shadeBurn = withEnv.environmentalBurnTimes?.shade;
 			expect(withEnv.burnTime).toBeDefined();
-			expect(withEnv.environmentalBurnTimes?.snow).toBeDefined();
-			expect(withEnv.environmentalBurnTimes?.shade).toBeDefined();
+			expect(snowBurn).toBeDefined();
+			expect(shadeBurn).toBeDefined();
+			if (!withEnv.burnTime || !snowBurn || !shadeBurn) {
+				throw new Error("expected burn times for base, snow, and shade");
+			}
 
-			const baseMs =
-				withEnv.burnTime!.getTime() - input.currentTime.getTime();
+			const baseMs = withEnv.burnTime.getTime() - input.currentTime.getTime();
 			const naiveSnowMs = baseMs / ENVIRONMENTAL_MULTIPLIERS.SNOW;
-			const integratedSnowMs =
-				withEnv.environmentalBurnTimes!.snow!.getTime() -
-				input.currentTime.getTime();
-			const shadeMs =
-				withEnv.environmentalBurnTimes!.shade!.getTime() -
-				input.currentTime.getTime();
+			const integratedSnowMs = snowBurn.getTime() - input.currentTime.getTime();
+			const shadeMs = shadeBurn.getTime() - input.currentTime.getTime();
 
 			// Ordering from dose-rate scaling
 			expect(integratedSnowMs).toBeLessThan(baseMs);
 			expect(shadeMs).toBeGreaterThan(baseMs);
 			// Material difference from post-hoc time division (non-linear SPF/UV path)
-			expect(Math.abs(integratedSnowMs - naiveSnowMs)).toBeGreaterThan(
-				60_000,
-			);
+			expect(Math.abs(integratedSnowMs - naiveSnowMs)).toBeGreaterThan(60_000);
 		});
 
 		it("calculateEnvironmentalBurnTimes returns ordered risk snow < sand < shade", () => {
@@ -718,10 +721,12 @@ describe("Sunburn Calculation Algorithm", () => {
 			expect(env.snow).toBeDefined();
 			expect(env.sand).toBeDefined();
 			expect(env.shade).toBeDefined();
+			if (!env.snow || !env.sand || !env.shade) {
+				throw new Error("expected snow, sand, and shade burn times");
+			}
 
-			const t = (d?: Date) => d!.getTime();
-			expect(t(env.snow)).toBeLessThan(t(env.sand));
-			expect(t(env.sand)).toBeLessThan(t(env.shade));
+			expect(env.snow.getTime()).toBeLessThan(env.sand.getTime());
+			expect(env.sand.getTime()).toBeLessThan(env.shade.getTime());
 		});
 	});
 });

--- a/src/calculations.ts
+++ b/src/calculations.ts
@@ -181,7 +181,6 @@ function calculateBurnTimeWithSlices(
 	const baseSpfValue =
 		SPF_CONFIG[input.spfLevel]?.coefficient ??
 		SPF_CONFIG[SPFLevel.NONE].coefficient;
-	// Scale erythemally effective dose rate (albedo / shade), not final clock time.
 	const environmentalFactor = Math.max(0, input.environmentalFactor ?? 1);
 	const startTimestampMs = input.currentTime.getTime();
 	const threshold = CALCULATION_CONSTANTS.DAMAGE_THRESHOLD;
@@ -299,15 +298,10 @@ function findOptimalTimeSlicingCore(
 	return calculateBurnTimeWithSlices(input, 4);
 }
 
-/**
- * Re-integrate the dose model under snow / sand / shade irradiance scales.
- * Each scenario scales effective UV dose rate, then accumulates damage over
- * the same hourly UV forecast (handles variable UV + SPF decay correctly).
- */
+/** Burn times under snow / sand / shade irradiance scales. */
 export function calculateEnvironmentalBurnTimes(
 	input: CalculationInput,
 ): EnvironmentalBurnTimes {
-	// Avoid recursive scenario nesting if already computing an alternate env.
 	const baseInput = { ...input, environmentalFactor: undefined };
 	return {
 		shade: findOptimalTimeSlicingCore({

--- a/src/calculations.ts
+++ b/src/calculations.ts
@@ -5,6 +5,7 @@ import type {
 	TimeSlice,
 	HourlyWeather,
 	FitzpatrickType,
+	EnvironmentalBurnTimes,
 } from "./types";
 import {
 	SweatLevel,
@@ -13,6 +14,7 @@ import {
 	SKIN_TYPE_CONFIG,
 	SPF_CONFIG,
 	SWEAT_CONFIG,
+	ENVIRONMENTAL_MULTIPLIERS,
 } from "./types";
 import { getHoursInTimezone } from "./utils/timezone";
 
@@ -179,6 +181,8 @@ function calculateBurnTimeWithSlices(
 	const baseSpfValue =
 		SPF_CONFIG[input.spfLevel]?.coefficient ??
 		SPF_CONFIG[SPFLevel.NONE].coefficient;
+	// Scale erythemally effective dose rate (albedo / shade), not final clock time.
+	const environmentalFactor = Math.max(0, input.environmentalFactor ?? 1);
 	const startTimestampMs = input.currentTime.getTime();
 	const threshold = CALCULATION_CONSTANTS.DAMAGE_THRESHOLD;
 	const points: CalculationPoint[] = [];
@@ -225,9 +229,12 @@ function calculateBurnTimeWithSlices(
 		// **Effective irradiance: UV strength divided by SPF, weighted for low UV. Average start/end for smooth integration.**
 		const effectiveIrradianceStart =
 			(uviAtEffectiveStart / Math.max(1, spfAtEffectiveStart)) *
-			lowUvWeight(uviAtEffectiveStart);
+			lowUvWeight(uviAtEffectiveStart) *
+			environmentalFactor;
 		const effectiveIrradianceEnd =
-			(uviAtEnd / Math.max(1, spfAtEnd)) * lowUvWeight(uviAtEnd);
+			(uviAtEnd / Math.max(1, spfAtEnd)) *
+			lowUvWeight(uviAtEnd) *
+			environmentalFactor;
 		const averageEffectiveIrradiance =
 			0.5 * (effectiveIrradianceStart + effectiveIrradianceEnd);
 		// Damage% added in this (possibly partial) window
@@ -279,7 +286,7 @@ function calculateBurnTimeWithSlices(
 
 // **Find optimal time slicing
 // Tries coarser slices first (fewer points) for efficiency, falls back to finer if too many points.**
-export function findOptimalTimeSlicing(
+function findOptimalTimeSlicingCore(
 	input: CalculationInput,
 ): CalculationResult {
 	const sliceOptions = [30, 12, 6, 4]; // 2, 5, 10, 15 minute intervals
@@ -290,4 +297,45 @@ export function findOptimalTimeSlicing(
 		}
 	}
 	return calculateBurnTimeWithSlices(input, 4);
+}
+
+/**
+ * Re-integrate the dose model under snow / sand / shade irradiance scales.
+ * Each scenario scales effective UV dose rate, then accumulates damage over
+ * the same hourly UV forecast (handles variable UV + SPF decay correctly).
+ */
+export function calculateEnvironmentalBurnTimes(
+	input: CalculationInput,
+): EnvironmentalBurnTimes {
+	// Avoid recursive scenario nesting if already computing an alternate env.
+	const baseInput = { ...input, environmentalFactor: undefined };
+	return {
+		shade: findOptimalTimeSlicingCore({
+			...baseInput,
+			environmentalFactor: ENVIRONMENTAL_MULTIPLIERS.SHADE,
+		}).burnTime,
+		sand: findOptimalTimeSlicingCore({
+			...baseInput,
+			environmentalFactor: ENVIRONMENTAL_MULTIPLIERS.SAND,
+		}).burnTime,
+		snow: findOptimalTimeSlicingCore({
+			...baseInput,
+			environmentalFactor: ENVIRONMENTAL_MULTIPLIERS.SNOW,
+		}).burnTime,
+	};
+}
+
+export function findOptimalTimeSlicing(
+	input: CalculationInput,
+	options?: { includeEnvironmentalScenarios?: boolean },
+): CalculationResult {
+	const result = findOptimalTimeSlicingCore(input);
+	if (!options?.includeEnvironmentalScenarios) {
+		return result;
+	}
+
+	return {
+		...result,
+		environmentalBurnTimes: calculateEnvironmentalBurnTimes(input),
+	};
 }

--- a/src/components/ResultsDisplay.tsx
+++ b/src/components/ResultsDisplay.tsx
@@ -2,18 +2,76 @@ import { useMemo } from "react";
 import { Sun, CheckCircle } from "lucide-react";
 import { format } from "date-fns";
 import { Card, CardContent } from "./ui/card";
-import type { CalculationResult } from "../types";
+import type { CalculationResult, EnvironmentalBurnTimes } from "../types";
 import { CALCULATION_CONSTANTS } from "../types";
-import { getHoursInTimezone } from "../utils/timezone";
-import { formatDuration, calculateEnvironmentalTimes } from "../lib/utils";
+import {
+	formatInTimeZone,
+	getHoursInTimezone,
+	toTZDate,
+} from "../utils/timezone";
+import { formatDuration } from "../lib/utils";
 
 interface ResultsDisplayProps {
 	result: CalculationResult;
 	timezone?: string;
 }
 
+/**
+ * True when burnTime falls on a later calendar day than startTime
+ * in the weather location's timezone (not the browser's local TZ).
+ */
+function isNextCalendarDay(
+	startTime: Date,
+	burnTime: Date,
+	timezone?: string,
+): boolean {
+	if (timezone) {
+		const startDay = formatInTimeZone(startTime, timezone, "yyyy-MM-dd");
+		const burnDay = formatInTimeZone(burnTime, timezone, "yyyy-MM-dd");
+		return burnDay !== startDay;
+	}
+	// Fallback: full local calendar date (not getDate() alone — that collides across months)
+	const start = toTZDate(startTime);
+	const burn = toTZDate(burnTime);
+	return (
+		start.getFullYear() !== burn.getFullYear() ||
+		start.getMonth() !== burn.getMonth() ||
+		start.getDate() !== burn.getDate()
+	);
+}
+
+/** Format a scenario burn duration, or "unlikely" if no burn / past local midnight. */
+function formatScenarioDuration(
+	startTime: Date | undefined,
+	burnTime: Date | undefined,
+	timezone?: string,
+): string {
+	if (
+		!startTime ||
+		!burnTime ||
+		isNextCalendarDay(startTime, burnTime, timezone)
+	) {
+		return "unlikely";
+	}
+	return formatDuration(burnTime.getTime() - startTime.getTime());
+}
+
+function hasAnyEnvironmentalScenario(
+	times: EnvironmentalBurnTimes | undefined,
+): boolean {
+	return !!(times?.shade || times?.sand || times?.snow);
+}
+
+function formatBurnClock(burnTime: Date, timezone?: string): string {
+	if (timezone) {
+		return formatInTimeZone(burnTime, timezone, "h:mm a");
+	}
+	return format(burnTime, "h:mm a");
+}
+
 export function ResultsDisplay({ result, timezone }: ResultsDisplayProps) {
-	const { burnTime, startTime, points, advice } = result;
+	const { burnTime, startTime, points, advice, environmentalBurnTimes } =
+		result;
 
 	const finalDamage = useMemo(() => {
 		if (points.length === 0) return 0;
@@ -24,24 +82,37 @@ export function ResultsDisplay({ result, timezone }: ResultsDisplayProps) {
 	const safeTime = useMemo(() => {
 		if (!startTime || !burnTime) return null;
 
-		// Check if burn time is past midnight (next day)
-		const startDate = new Date(startTime);
-		const burnDate = new Date(burnTime);
-		const isNextDay = burnDate.getDate() !== startDate.getDate();
-		const isPastMidnight = isNextDay;
-
-		if (isPastMidnight) {
+		if (isNextCalendarDay(startTime, burnTime, timezone)) {
 			return "unlikely";
 		}
 
 		const diffMs = burnTime.getTime() - startTime.getTime();
 		return formatDuration(diffMs);
-	}, [startTime, burnTime]);
+	}, [startTime, burnTime, timezone]);
 
-	const environmentalTimes = useMemo(() => {
-		if (!startTime || !burnTime || safeTime === "unlikely") return null;
-		return calculateEnvironmentalTimes(startTime, burnTime);
-	}, [startTime, burnTime, safeTime]);
+	const environmentalLabels = useMemo(() => {
+		if (!startTime || !hasAnyEnvironmentalScenario(environmentalBurnTimes)) {
+			return null;
+		}
+		// Prefer main result startTime so labels stay aligned with "Safe for…"
+		return {
+			shade: formatScenarioDuration(
+				startTime,
+				environmentalBurnTimes?.shade,
+				timezone,
+			),
+			sand: formatScenarioDuration(
+				startTime,
+				environmentalBurnTimes?.sand,
+				timezone,
+			),
+			snow: formatScenarioDuration(
+				startTime,
+				environmentalBurnTimes?.snow,
+				timezone,
+			),
+		};
+	}, [startTime, environmentalBurnTimes, timezone]);
 
 	const isHighRisk = useMemo(() => {
 		// If sunburn is unlikely, it's not high risk
@@ -57,7 +128,7 @@ export function ResultsDisplay({ result, timezone }: ResultsDisplayProps) {
 					CALCULATION_CONSTANTS.HIGH_RISK_TIME_LIMIT_HOURS
 				: false;
 
-		// Check if burn occurs during high UV hours (before 6 PM)
+		// Check if burn occurs during high UV hours (before 6 PM local to weather site)
 		const burnHour = burnTime
 			? timezone
 				? getHoursInTimezone(burnTime, timezone)
@@ -90,21 +161,32 @@ export function ResultsDisplay({ result, timezone }: ResultsDisplayProps) {
 									</p>
 									<p className="text-slate-600 tabular-nums">
 										{isHighRisk
-											? `Use sunscreen by ${format(burnTime, "h:mm a")}, sun damage may occur after`
-											: `Until ${format(burnTime, "h:mm a")}`}
+											? `Use sunscreen by ${formatBurnClock(burnTime, timezone)}, sun damage may occur after`
+											: `Until ${formatBurnClock(burnTime, timezone)}`}
 									</p>
-									{environmentalTimes && (
+									{environmentalLabels && (
 										<p className="text-sm tabular-nums text-slate-500 mt-2">
-											Full shade: {environmentalTimes.shade} • Beach:{" "}
-											{environmentalTimes.sand} • Snow:{" "}
-											{environmentalTimes.snow}
+											Full shade: {environmentalLabels.shade} • Beach:{" "}
+											{environmentalLabels.sand} • Snow:{" "}
+											{environmentalLabels.snow}
 										</p>
 									)}
 								</div>
 							) : (
-								<p className="text-2xl font-bold text-green-600">
-									Sunburn unlikely
-								</p>
+								<div>
+									<p className="text-2xl font-bold text-green-600">
+										Sunburn unlikely
+									</p>
+									{environmentalLabels &&
+										(environmentalLabels.snow !== "unlikely" ||
+											environmentalLabels.sand !== "unlikely") && (
+											<p className="text-sm tabular-nums text-slate-500 mt-2">
+												Full shade: {environmentalLabels.shade} • Beach:{" "}
+												{environmentalLabels.sand} • Snow:{" "}
+												{environmentalLabels.snow}
+											</p>
+										)}
+								</div>
 							)}
 						</div>
 					</div>

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -101,22 +101,5 @@ export function formatDuration(diffMs: number): string {
 	}
 }
 
-/**
- * Environmental UV multipliers based on scientific research
- * Snow: 88% reflection, Sand: 15% reflection, Shade: 50% reduction
- */
-export const ENVIRONMENTAL_MULTIPLIERS = {
-	SNOW: 1.88,
-	SAND: 1.15,
-	SHADE: 0.5,
-} as const;
-
-export function calculateEnvironmentalTimes(startTime: Date, burnTime: Date) {
-	const baseDiffMs = burnTime.getTime() - startTime.getTime();
-
-	return {
-		snow: formatDuration(baseDiffMs / ENVIRONMENTAL_MULTIPLIERS.SNOW),
-		sand: formatDuration(baseDiffMs / ENVIRONMENTAL_MULTIPLIERS.SAND),
-		shade: formatDuration(baseDiffMs / ENVIRONMENTAL_MULTIPLIERS.SHADE),
-	};
-}
+// Environmental multipliers live in types.ts and scale dose rate inside
+// calculations.ts. Scenario burn times are re-integrated, not final-time scaled.

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -100,6 +100,3 @@ export function formatDuration(diffMs: number): string {
 		return `${hours}h ${minutes}m`;
 	}
 }
-
-// Environmental multipliers live in types.ts and scale dose rate inside
-// calculations.ts. Scenario burn times are re-integrated, not final-time scaled.

--- a/src/types.ts
+++ b/src/types.ts
@@ -204,6 +204,17 @@ export interface GeolocationState {
 	error?: string;
 }
 
+// Environmental UV multipliers (albedo / shade)
+// Applied as a scale on erythemally effective irradiance (dose rate), not final time.
+// Snow ~88% extra reflection, sand ~15%, shade ~50% reduction of open-sky dose.
+export const ENVIRONMENTAL_MULTIPLIERS = {
+	SNOW: 1.88,
+	SAND: 1.15,
+	SHADE: 0.5,
+} as const;
+
+export type EnvironmentalCondition = keyof typeof ENVIRONMENTAL_MULTIPLIERS;
+
 // Calculation Models
 export interface CalculationInput {
 	weather: WeatherData;
@@ -212,6 +223,8 @@ export interface CalculationInput {
 	skinType: FitzpatrickType;
 	spfLevel: SPFLevel;
 	sweatLevel: SweatLevel;
+	/** Scales effective UV dose rate (default 1). Used for snow/sand/shade scenarios. */
+	environmentalFactor?: number;
 }
 
 export interface TimeSlice {
@@ -225,12 +238,23 @@ export interface CalculationPoint {
 	totalDamageAtStart: number;
 }
 
+export interface EnvironmentalBurnTimes {
+	/** Burn time under full shade (dose rate × 0.5) */
+	shade?: Date;
+	/** Burn time on sand/beach (dose rate × 1.15) */
+	sand?: Date;
+	/** Burn time on snow (dose rate × 1.88) */
+	snow?: Date;
+}
+
 export interface CalculationResult {
 	startTime?: Date;
 	burnTime?: Date;
 	points: CalculationPoint[];
 	timeSlices: number;
 	advice: string[];
+	/** Alternate environments, each re-integrated with scaled dose rate */
+	environmentalBurnTimes?: EnvironmentalBurnTimes;
 }
 
 // App State

--- a/src/types.ts
+++ b/src/types.ts
@@ -204,9 +204,8 @@ export interface GeolocationState {
 	error?: string;
 }
 
-// Environmental UV multipliers (albedo / shade)
-// Applied as a scale on erythemally effective irradiance (dose rate), not final time.
-// Snow ~88% extra reflection, sand ~15%, shade ~50% reduction of open-sky dose.
+// Environmental UV multipliers (albedo / shade on effective irradiance).
+// Snow ~88% extra reflection, sand ~15%, shade ~50% of open-sky dose.
 export const ENVIRONMENTAL_MULTIPLIERS = {
 	SNOW: 1.88,
 	SAND: 1.15,
@@ -223,7 +222,7 @@ export interface CalculationInput {
 	skinType: FitzpatrickType;
 	spfLevel: SPFLevel;
 	sweatLevel: SweatLevel;
-	/** Scales effective UV dose rate (default 1). Used for snow/sand/shade scenarios. */
+	/** Multiplier on effective UV irradiance (default 1). */
 	environmentalFactor?: number;
 }
 
@@ -239,11 +238,8 @@ export interface CalculationPoint {
 }
 
 export interface EnvironmentalBurnTimes {
-	/** Burn time under full shade (dose rate × 0.5) */
 	shade?: Date;
-	/** Burn time on sand/beach (dose rate × 1.15) */
 	sand?: Date;
-	/** Burn time on snow (dose rate × 1.88) */
 	snow?: Date;
 }
 
@@ -253,7 +249,6 @@ export interface CalculationResult {
 	points: CalculationPoint[];
 	timeSlices: number;
 	advice: string[];
-	/** Alternate environments, each re-integrated with scaled dose rate */
 	environmentalBurnTimes?: EnvironmentalBurnTimes;
 }
 


### PR DESCRIPTION
## Summary
- Apply snow / sand / shade multipliers to **effective UV dose rate** inside the burn calculation, then re-integrate each scenario over the forecast (handles variable UV + SPF decay correctly).
- Remove post-hoc `finalDuration / multiplier` scaling from `utils`.
- Fix `ResultsDisplay` calendar-day “unlikely” checks (and burn clock formatting) to use the **weather location timezone**, not the browser local TZ.

## Why
Post-hoc time division is only correct under constant UV and constant SPF. With rising UV or sunscreen decay, clock time does not scale as `1 / factor`. Re-integrating the dose model is more scientifically honest.

## Test plan
- [x] `bun test src/calculations.test.ts` (includes environmental dose-rate cases)
- [ ] Manual: pick a location, confirm beach/snow/shade labels appear and ordering is snow &lt; base &lt; shade under high UV
- [ ] Manual: search a far timezone location near midnight there; “unlikely” should follow that calendar day, not the browser’s
- [ ] Manual: burn clock (`Until h:mm a`) matches location local time